### PR TITLE
Add cargo-make

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,16 @@ We are still trying to figure this out but:
 # Install rustup
 curl https://sh.rustup.rs -sSf | sh
 
-# Default to nightly on this directory
-rustup override add nightly
-
-# Install xargo and xbuild
-rustup component add rust-src
-cargo install xargo
-cargo install cargo-xbuild
+# Install cargo-make
+cargo install cargo-make
 
 # Ocassionally run:
 rustup update
 
 # Build for ARMv7
 cd src/mainboard/emulation/qemu-armv7
-cargo xbuild            # Debug
-cargo xbuild --release  # Optimized
-
-# Create a ROM image
-arm-none-eabi-objcopy -O binary target/arm-none-eabihf/release/qemu-armv7 oreboot.rom
+cargo make              # Debug
+cargo make -p release   # Optimized
 
 # View disassembly
 arm-none-eabi-objdump -S target/arm-none-eabihf/release/qemu-armv7
@@ -56,7 +48,7 @@ QEMU
 ----
 
 ```
-qemu-system-arm -machine virt -bios target/arm-none-eabihf/release/qemu-armv7 -nographic
+cargo make run -p release
 
 # Quit qemu with CTRL-A X
 ```

--- a/src/mainboard/emulation/qemu-armv7/Makefile.toml
+++ b/src/mainboard/emulation/qemu-armv7/Makefile.toml
@@ -2,10 +2,18 @@
 # no default tasks
 skip_core_tasks = true
 
+[env.development]
+CARGO_ARGS = "--verbose"
+TARGET_DIR = "target/arm-none-eabihf/debug/"
+
+[env.release]
+CARGO_ARGS = "--release --verbose"
+TARGET_DIR = "target/arm-none-eabihf/release/"
+
 [tasks.default]
 dependencies = [ "build" ]
 script = [
-	"arm-none-eabi-objcopy -O binary target/arm-none-eabihf/release/qemu-armv7 target/arm-none-eabihf/release/bios.bin"
+	"arm-none-eabi-objcopy -O binary ${TARGET_DIR}/qemu-armv7 ${TARGET_DIR}/oreboot.bin"
 ]
 
 [tasks.install-rust-src]
@@ -15,9 +23,9 @@ install_crate = { rustup_component_name = "rust-src" }
 dependencies = [ "install-rust-src" ]
 toolchain = "nightly"
 command = "cargo"
-args = ["xbuild", "--release"]
+args = ["xbuild", "@@split(CARGO_ARGS, )"]
 
 [tasks.run]
-dependencies = ["build"]
+dependencies = ["default"]
 command = "qemu-system-arm"
-args = ["-machine", "virt", "-bios", "target/arm-none-eabihf/release/bios.bin", "-nographic"]
+args = ["-machine", "virt", "-bios", "${TARGET_DIR}/oreboot.bin", "-nographic"]

--- a/src/mainboard/emulation/qemu-armv7/Makefile.toml
+++ b/src/mainboard/emulation/qemu-armv7/Makefile.toml
@@ -1,0 +1,23 @@
+[config]
+# no default tasks
+skip_core_tasks = true
+
+[tasks.default]
+dependencies = [ "build" ]
+script = [
+	"arm-none-eabi-objcopy -O binary target/arm-none-eabihf/release/qemu-armv7 target/arm-none-eabihf/release/bios.bin"
+]
+
+[tasks.install-rust-src]
+install_crate = { rustup_component_name = "rust-src" }
+
+[tasks.build]
+dependencies = [ "install-rust-src" ]
+toolchain = "nightly"
+command = "cargo"
+args = ["xbuild", "--release"]
+
+[tasks.run]
+dependencies = ["build"]
+command = "qemu-system-arm"
+args = ["-machine", "virt", "-bios", "target/arm-none-eabihf/release/bios.bin", "-nographic"]


### PR DESCRIPTION
Adds cargo-make support to the project to streamline building oreboot.