### PR TITLE
Fix warnings related to missing "dyn"

### DIFF
--- a/drivers/src/wrappers.rs
+++ b/drivers/src/wrappers.rs
@@ -4,11 +4,11 @@ use core::slice::{from_raw_parts, from_raw_parts_mut};
 use crate::model::*;
 
 pub struct DoD<'a> {
-    drivers: &'a mut [&'a mut Driver],
+    drivers: &'a mut [&'a mut dyn Driver],
 }
 
 impl<'a> DoD<'a> {
-    pub fn new(drivers: &'a mut [&'a mut Driver]) -> DoD<'a> {
+    pub fn new(drivers: &'a mut [&'a mut dyn Driver]) -> DoD<'a> {
         DoD { drivers }
     }
 }
@@ -87,13 +87,13 @@ impl<'a> Driver for SliceReader<'a> {
 
 /// The driver reads from a section (offset+size) of another driver.
 pub struct SectionReader<'a> {
-    driver: &'a Driver,
+    driver: &'a dyn Driver,
     offset: usize,
     size: usize,
 }
 
 impl<'a> SectionReader<'a> {
-    pub fn new(driver: &'a Driver, offset: usize, size: usize) -> SectionReader {
+    pub fn new(driver: &'a dyn Driver, offset: usize, size: usize) -> SectionReader {
         SectionReader { driver, offset, size }
     }
 }

--- a/src/lib/device_tree/device_tree.rs
+++ b/src/lib/device_tree/device_tree.rs
@@ -64,20 +64,20 @@ pub struct FdtReader<'a> {
     strings_block: SectionReader<'a>,
 }
 
-fn read_u32(drv: &Driver, offset: usize) -> Result<u32> {
+fn read_u32(drv: &dyn Driver, offset: usize) -> Result<u32> {
     let mut data = [0; 4];
     drv.pread(&mut data, offset)?;
     Ok(BigEndian::read_u32(&data))
 }
 
-fn cursor_u32(drv: &Driver, cursor: &mut usize) -> Result<u32> {
+fn cursor_u32(drv: &dyn Driver, cursor: &mut usize) -> Result<u32> {
     let mut data = [0; 4];
     *cursor += drv.pread(&mut data, *cursor)?;
     Ok(BigEndian::read_u32(&data))
 }
 
 // Reads a string (including null-terminator). Returns bytes read.
-fn cursor_string(drv: &Driver, cursor: &mut usize, buf: &mut [u8]) -> Result<usize> {
+fn cursor_string(drv: &dyn Driver, cursor: &mut usize, buf: &mut [u8]) -> Result<usize> {
     for i in 0..buf.len() {
         *cursor += drv.pread(&mut buf[i..i + 1], *cursor)?;
         if buf[i] == 0 {
@@ -94,7 +94,7 @@ fn align4(x: usize) -> usize {
 /// In-memory device tree traversal.
 /// Does not perform any sanity checks.
 impl<'a> FdtReader<'a> {
-    pub fn new(drv: &'a Driver) -> Result<FdtReader<'a>> {
+    pub fn new(drv: &'a dyn Driver) -> Result<FdtReader<'a>> {
         let header = FdtHeader {
             magic: read_u32(drv, 0x0)?,
             total_size: read_u32(drv, 0x4)?,

--- a/src/mainboard/emulation/qemu-armv7/src/main.rs
+++ b/src/mainboard/emulation/qemu-armv7/src/main.rs
@@ -42,7 +42,7 @@ pub extern "C" fn _start() -> ! {
 }
 use core::panic::PanicInfo;
 
-pub fn print_fdt(console: &mut Driver) -> Result<()> {
+pub fn print_fdt(console: &mut dyn Driver) -> Result<()> {
     let mut w = print::WriteTo::new(console);
     let spi = SliceReader::new(zimage::DTB);
 

--- a/src/mainboard/emulation/qemu-armv7/src/print.rs
+++ b/src/mainboard/emulation/qemu-armv7/src/print.rs
@@ -2,11 +2,11 @@ use core::fmt;
 use drivers::model::Driver;
 
 pub struct WriteTo<'a> {
-    drv: &'a mut Driver,
+    drv: &'a mut dyn Driver,
 }
 
 impl<'a> WriteTo<'a> {
-    pub fn new(drv: &'a mut Driver) -> Self {
+    pub fn new(drv: &'a mut dyn Driver) -> Self {
         WriteTo { drv: drv }
     }
 }


### PR DESCRIPTION
  warning: trait objects without an explicit `dyn` are deprecated

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>