### PR TITLE
Add a flash target

### DIFF
--- a/src/mainboard/ast/ast25x0/Makefile.toml
+++ b/src/mainboard/ast/ast25x0/Makefile.toml
@@ -35,3 +35,8 @@ args = ["-m", "512m", "-machine", "ast2500-evb", "-nographic", "-drive", "file=$
 dependencies = ["default"]
 command = "qemu-system-arm"
 args = ["-m", "512m", "-machine", "ast2500-evb", "-nographic", "-drive", "file=${TARGET_DIR}oreboot.bin,format=raw,if=mtd", "-d", "guest_errors", "-s", "-S"]
+
+[tasks.flash]
+dependencies = ["default"]
+command = "sudo"
+args = ["flashrom", "-p", "dediprog", "-w", "target/arm-none-eabihf/release/oreboot.bin"]


### PR DESCRIPTION
You can now say
RUST_TARGET_PATH=$(pwd) cargo make -p  release flash

and it will build the target and run flashrom