### PR TITLE
add a 'log uart'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ defconfig
 .coreboot-version
 .xcompile
 .ccwrap
+oreboot.asm
 build/
 coreboot-builds/
 payloads/coreinfo/lpbuild/

--- a/src/drivers/uart/Cargo.toml
+++ b/src/drivers/uart/Cargo.toml
@@ -10,8 +10,10 @@ opt-level = 'z'  # Optimize for size.
 [dependencies]
 model = { path = "../model"}
 register = "0.3.2"
+heapless = "0.4.x"
 
 [features]
 pl011 = []
 ns16550 = []
 sifive = []
+log = []

--- a/src/drivers/uart/src/lib.rs
+++ b/src/drivers/uart/src/lib.rs
@@ -6,3 +6,5 @@ pub mod ns16550;
 pub mod pl011;
 #[cfg(feature = "sifive")]
 pub mod sifive;
+#[cfg(feature = "log")]
+pub mod log;

--- a/src/drivers/uart/src/log.rs
+++ b/src/drivers/uart/src/log.rs
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the oreboot project.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/*
+ * UART that just pushes into a vec.
+ */
+
+use model::*;
+extern crate heapless; // v0.4.x
+use heapless::consts::*;
+
+use heapless::Vec;
+
+pub struct Log<'a> {
+    dat: &'a mut Vec<u8, U1024>,
+}
+
+impl<'a> Log<'a> {
+    pub fn new(v: &'a mut Vec<u8, U1024>) -> Log {
+        Log{dat: v}
+    }
+}
+
+impl<'a> Driver for Log<'a> {
+    fn init(&mut self) {   }
+
+    fn pread(&self, data: &mut [u8], _offset: usize) -> Result<usize> {
+        return Ok(0);
+    }
+
+    fn pwrite(&mut self, data: &[u8], _offset: usize) -> Result<usize> {
+        for (i, &c) in data.iter().enumerate() {
+            self.dat.push(c);
+        }
+        Ok(data.len())
+    }
+
+    fn shutdown(&mut self) {}
+}

--- a/src/drivers/uart/src/sifive.rs
+++ b/src/drivers/uart/src/sifive.rs
@@ -95,8 +95,7 @@ impl SiFive {
 
 impl Driver for SiFive {
     fn init(&mut self) {
-        self.IE.set(0xaa55aa55u32);
-        loop{};
+        self.IE.set(0 as u32);
 //        self.BR.write(LC::DivisorLatchAccessBit::BaudRate);
         // Until we know the clock rate the divisor values are kind of
         // impossible to know. Throw in a phony value.
@@ -113,12 +112,12 @@ impl Driver for SiFive {
     }
 
     fn pwrite(&mut self, data: &[u8], _offset: usize) -> Result<usize> {
-        return Ok(0);
         for (i, &c) in data.iter().enumerate() {
-            if self.TD.is_set(TD::Full) {
-                return Ok(i);
-            }
-            // ? self.TD.Data.set(c);
+            // TODO: give up after 100k tries.
+            while self.TD.is_set(TD::Full) {}
+                //return Ok(i);
+            //}
+            self.TD.set(c.into());
         }
         Ok(data.len())
     }

--- a/src/mainboard/sifive/hifive/Cargo.lock
+++ b/src/mainboard/sifive/hifive/Cargo.lock
@@ -5,6 +5,15 @@ name = "architecture"
 version = "0.1.0"
 
 [[package]]
+name = "as-slice"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,12 +39,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hash32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heapless"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hifive"
 version = "0.1.0"
 dependencies = [
  "architecture 0.1.0",
  "console 0.1.0",
  "device_tree 0.1.0",
+ "heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "model 0.1.0",
  "payloads 0.1.0",
  "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -103,6 +147,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "static-ref"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,9 +172,15 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uart"
 version = "0.1.0"
 dependencies = [
+ "heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "model 0.1.0",
  "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -143,14 +198,21 @@ dependencies = [
 ]
 
 [metadata]
+"checksum as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "293dac66b274fab06f95e7efb05ec439a6b70136081ea522d270bc351ae5bb27"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+"checksum generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8107dafa78c80c848b71b60133954b4a58609a3a1a5f9af037ecc7f67280f369"
+"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
+"checksum heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ae80bbc62401ae8096976857172507cadbd2200f36670e5144634360a05959"
 "checksum num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "469bb5ddde81d67fb8bba4e14d77689b8166cfd077abe7530591cefe29d05823"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static-ref 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c13349fd3abcbb70dd954f300f5c0c27b71a94f4697adc301501de2c6934d0"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
 "checksum tock-registers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c758f5195a2e0df9d9fecf6f506506b2766ff74cf64db1e995c87e2761a5c3e2"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/src/mainboard/sifive/hifive/Cargo.toml
+++ b/src/mainboard/sifive/hifive/Cargo.toml
@@ -12,12 +12,13 @@ device_tree = { path = "../../../lib/device_tree" }
 soc = { path = "../../../soc/sifive/fu540" }
 register = "0.3.2"
 static-ref = "0.1.1"
+heapless = "0.4.x"
 model = { path = "../../../drivers/model" }
 wrappers = { path = "../../../drivers/wrappers"}
 
 [dependencies.uart]
 path = "../../../drivers/uart"
-features = ["sifive"]
+features = ["sifive", "log"]
 
 [profile.release]
 opt-level = 'z'  # Optimize for size.

--- a/src/mainboard/sifive/hifive/Makefile.toml
+++ b/src/mainboard/sifive/hifive/Makefile.toml
@@ -29,6 +29,11 @@ args = ["xbuild", "@@split(CARGO_ARGS, )"]
 [tasks.run]
 dependencies = ["default"]
 command = "qemu-system-riscv64"
+args = ["-m", "512m", "-machine", "sifive_u", "-nographic", "-bios", "${TARGET_DIR}hifive", ]
+
+[tasks.trace]
+dependencies = ["default"]
+command = "qemu-system-riscv64"
 args = ["-m", "512m", "-machine", "sifive_u", "-nographic", "-bios", "${TARGET_DIR}hifive", "-d", "guest_errors,in_asm"]
 
 [tasks.gdb]

--- a/src/mainboard/sifive/hifive/src/main.rs
+++ b/src/mainboard/sifive/hifive/src/main.rs
@@ -6,16 +6,23 @@
 
 mod print;
 
+use heapless::Vec;
+use heapless::consts::*;
+
 use core::fmt;
 use core::fmt::Write;
 use model::Driver;
 use uart::sifive::SiFive;
+use uart::log::Log;
 use wrappers::DoD;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    let mut v: Vec<u8, U1024> = Vec::new();
     let mut uarts = [
-        &mut SiFive::new(/*soc::UART0*/0x10010000, 115200) as &mut dyn Driver,
+        &mut SiFive::new(/*soc::UART0*/0x10013000, 115200) as &mut dyn Driver,
+        &mut SiFive::new(/*soc::UART1*/0x10023000, 115200) as &mut dyn Driver,
+        &mut Log::new(&mut v) as &mut dyn Driver,
     ];
     let console = &mut DoD::new(&mut uarts[..]);
     console.init();

--- a/src/mainboard/sifive/hifive/src/print.rs
+++ b/src/mainboard/sifive/hifive/src/print.rs
@@ -1,0 +1,21 @@
+use core::fmt;
+use model::Driver;
+
+pub struct WriteTo<'a> {
+    drv: &'a mut dyn Driver,
+}
+
+impl<'a> WriteTo<'a> {
+    pub fn new(drv: &'a mut dyn Driver) -> Self {
+        WriteTo { drv: drv }
+    }
+}
+
+impl<'a> fmt::Write for WriteTo<'a> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        match self.drv.pwrite(s.as_bytes(), 0) {
+            Err(_) => Err(fmt::Error),
+            _ => Ok(()),
+        }
+    }
+}


### PR DESCRIPTION
Just messing around. But this may be handy for debugging later
if we have jtage and can examine memory in qemu or jtag.

This brings up a questions why is print.rs appearing for each mainboard

we get very far if we don't use the sifive init()