### PR TITLE
Use llvm objcopy provided by cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,17 @@ cargo install cargo-make
 # Ocassionally run:
 rustup update
 
-# Install gcc for objdump and objcopy for your architecture.
-sudo apt install gcc-arm-none-eabi gdb-multiarch
-sudo apt install gcc-riscv64-linux-gnu gdb-multiarch
+# Install objcopy and other compiler tools.
+cargo install cargo-binutils
+rustup component add llvm-tools-preview
 
-# Build for ARMv7
-cd src/mainboard/emulation/qemu-armv7
-# TODO: Currently, we have to prepend RUST_TARGET_PATH so the compiler finds the
-#       path to the target json.
-RUST_TARGET_PATH=$(pwd) cargo make              # Debug
-RUST_TARGET_PATH=$(pwd) cargo make -p release   # Optimized
+# Build for RISC-V
+cd src/mainboard/sifive/hifive
+cargo make              # Debug
+cargo make -p release   # Optimized
 
 # View disassembly
-arm-none-eabi-objdump -S target/arm-none-eabihf/release/qemu-armv7
-# use -d instead of -S if you don't need to see the source
+cargo make objdump -p release
 ```
 
 QEMU
@@ -66,7 +63,7 @@ QEMU
 
 ```
 sudo apt-get install qemu-system-arm
-RUST_TARGET_PATH=$(pwd) cargo make run -p release
+cargo make run -p release
 
 # Quit qemu with CTRL-A X
 ```

--- a/src/mainboard/sifive/hifive/Makefile.toml
+++ b/src/mainboard/sifive/hifive/Makefile.toml
@@ -4,18 +4,16 @@ skip_core_tasks = true
 
 [env.development]
 CARGO_ARGS = "--verbose"
-TARGET_DIR = "target/riscv64imac-unknown-none-elf/debug/"
+TARGET_DIR = "target/riscv64imac-unknown-none-elf/debug"
 
 [env.release]
 CARGO_ARGS = "--release --verbose"
-TARGET_DIR = "target/riscv64imac-unknown-none-elf/release/"
+TARGET_DIR = "target/riscv64imac-unknown-none-elf/release"
 
 [tasks.default]
 dependencies = [ "build" ]
-script = [
-	"riscv64-linux-gnu-objcopy -O binary ${TARGET_DIR}/hifive ${TARGET_DIR}/oreboot.bin",
-	"riscv64-linux-gnu-objdump -d ${TARGET_DIR}/hifive > oreboot.asm"
-]
+command = "cargo"
+args = ["objcopy", "--", "-O", "binary", "${TARGET_DIR}/hifive", "${TARGET_DIR}/oreboot.bin"]
 
 [tasks.install-rust-src]
 install_crate = { rustup_component_name = "rust-src" }
@@ -40,3 +38,8 @@ args = ["-m", "512m", "-machine", "sifive_u", "-nographic", "-bios", "${TARGET_D
 dependencies = ["default"]
 command = "qemu-system-riscv64"
 args = ["-m", "512m", "-machine", "sifive_u", "-nographic", "-bios", "${TARGET_DIR}hifive", "-d", "guest_errors", "-s", "-S"]
+
+[tasks.objdump]
+dependencies = ["build"]
+command = "cargo"
+args = ["objdump", "--", "-d", "${TARGET_DIR}/hifive"]


### PR DESCRIPTION
This makes more sense than using the GCC objcopy since Rust is already
using llvm.

Signed-off-by: Ryan O'Leary <ryan@ryanoleary.ca>