### PR TITLE
riscv: Run WFI command when halting

### DIFF
--- a/src/arch/riscv/rv64/src/lib.rs
+++ b/src/arch/riscv/rv64/src/lib.rs
@@ -9,7 +9,7 @@ pub fn halt() -> ! {
     loop {
         // Bug with LLVM marks empty loops as undefined behaviour.
         // See: https://github.com/rust-lang/rust/issues/28728
-        unsafe { asm!("" :::: "volatile") }
+        unsafe { asm!("wfi" :::: "volatile") }
     }
 }
 


### PR DESCRIPTION
Instead of looping over no assembly let's loop over a WFI instruction
instead.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>