### PR TITLE
Fix warnings

### DIFF
--- a/payloads/src/external/zimage/mod.rs
+++ b/payloads/src/external/zimage/mod.rs
@@ -1,3 +1,4 @@
+/*
 use crate::payload;
 
 const KERNEL: &'static [u8] = include_bytes!("zImage");
@@ -7,7 +8,7 @@ pub const DTB: &'static [u8] = include_bytes!("qemu_fdt.dtb");
 const MEM: u32 = 0x40200000;
 
 // TODO: Parse from SPI.
-/*pub const PAYLOAD: payload::Payload = payload::Payload {
+pub const PAYLOAD: payload::Payload = payload::Payload {
     typ: payload::ftype::CBFS_TYPE_RAW,
     compression: payload::ctype::CBFS_COMPRESS_NONE,
     offset: 0,
@@ -29,4 +30,5 @@ const MEM: u32 = 0x40200000;
             data: DTB,
         },
     ],
-};*/
+};
+*/

--- a/payloads/src/lib.rs
+++ b/payloads/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![feature(const_slice_len)]
+#![deny(warnings)]
 
 pub mod external;
 pub mod payload;

--- a/src/arch/arm/armv7/src/lib.rs
+++ b/src/arch/arm/armv7/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(non_snake_case)]
 #![feature(global_asm)]
 
 pub fn init() {}

--- a/src/arch/arm/armv7/src/lib.rs
+++ b/src/arch/arm/armv7/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![feature(global_asm)]
+#![deny(warnings)]
 
 pub fn init() {}
 

--- a/src/arch/riscv/rv64/src/lib.rs
+++ b/src/arch/riscv/rv64/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(lang_items, start)]
 #![no_std]
 #![feature(global_asm)]
+#![deny(warnings)]
 
 use core::panic::PanicInfo;
 

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -1,3 +1,4 @@
 #![no_std]
+#![deny(warnings)]
 
 pub fn console_init() {}

--- a/src/cpu/armltd/cortex-a9/src/lib.rs
+++ b/src/cpu/armltd/cortex-a9/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(warnings)]
 
 pub fn init() {
     arch::init()

--- a/src/drivers/clock/src/lib.rs
+++ b/src/drivers/clock/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(warnings)]
 /// Trait to set the input clock rate on a driver.
 
 pub trait ClockNode {

--- a/src/drivers/model/src/lib.rs
+++ b/src/drivers/model/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(warnings)]
 
 pub type Result<T> = core::result::Result<T, &'static str>;
 

--- a/src/drivers/sifive/spi/src/lib.rs
+++ b/src/drivers/sifive/spi/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(warnings)]
 /// This is a driver for SiFive's SPI master, documented in the FU540 manual:
 
 use model::*;

--- a/src/drivers/uart/src/lib.rs
+++ b/src/drivers/uart/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![feature(asm)]
+#![deny(warnings)]
 
 #[cfg(feature = "ns16550")]
 pub mod ns16550;

--- a/src/drivers/uart/src/ns16550.rs
+++ b/src/drivers/uart/src/ns16550.rs
@@ -5,7 +5,6 @@ use core::ops;
 use register::mmio::{ReadOnly, ReadWrite};
 use register::{register_bitfields, Field};
 
-#[allow(non_snake_case)]
 #[repr(C)]
 pub struct RegisterBlock {
     D: ReadWrite<u32, D::Register>,

--- a/src/drivers/uart/src/pl011.rs
+++ b/src/drivers/uart/src/pl011.rs
@@ -3,7 +3,6 @@ use model::*;
 use register::mmio::{ReadOnly, ReadWrite};
 use register::{register_bitfields, Field};
 
-#[allow(non_snake_case)]
 #[repr(C)]
 struct RegisterBlock {
     UARTDR: ReadWrite<u32, UARTDR::Register>,

--- a/src/drivers/uart/src/sifive.rs
+++ b/src/drivers/uart/src/sifive.rs
@@ -26,7 +26,6 @@ use clock::ClockNode;
 use register::mmio::{ReadOnly, ReadWrite};
 use register::{register_bitfields};
 
-#[allow(non_snake_case)]
 #[repr(C)]
 pub struct RegisterBlock {
     TD: ReadWrite<u32, TD::Register>,	/* Transmit data register */

--- a/src/drivers/wrappers/src/lib.rs
+++ b/src/drivers/wrappers/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(non_snake_case)]
 
 use model::*;
 use core::slice::{from_raw_parts, from_raw_parts_mut};

--- a/src/drivers/wrappers/src/lib.rs
+++ b/src/drivers/wrappers/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(warnings)]
 
 use model::*;
 use core::slice::{from_raw_parts, from_raw_parts_mut};

--- a/src/lib/device_tree/src/lib.rs
+++ b/src/lib/device_tree/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(warnings)]
 
 #[macro_use]
 extern crate num_derive;

--- a/src/mainboard/ast/ast25x0/src/main.rs
+++ b/src/mainboard/ast/ast25x0/src/main.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![no_main]
 #![feature(global_asm)]
+#![deny(warnings)]
 
 mod print;
 mod romstage;

--- a/src/mainboard/ast/ast25x0/src/romstage/asmram.rs
+++ b/src/mainboard/ast/ast25x0/src/romstage/asmram.rs
@@ -1,12 +1,4 @@
 #![no_std]
-#![allow(non_snake_case)]
-#![allow(unused_attributes)]
-#![allow(unused_macros)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
-#![allow(unused_variables)]
-#![allow(unreachable_code)]
-#![allow(non_camel_case_types)]
 
 pub mod ramtable;
 #[macro_use]

--- a/src/mainboard/ast/ast25x0/src/romstage/asmram/ramtable.rs
+++ b/src/mainboard/ast/ast25x0/src/romstage/asmram/ramtable.rs
@@ -1,9 +1,4 @@
 #![no_std]
-#![allow(non_snake_case)]
-#![allow(unused_attributes)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
-#![allow(unused_variables)]
 
 pub static TIME_TABLE_DDR3_1333: [u32; 17] = [
     0x53503C37, //       @ 0x010

--- a/src/mainboard/ast/ast25x0/src/romstage/new.rs
+++ b/src/mainboard/ast/ast25x0/src/romstage/new.rs
@@ -1,9 +1,4 @@
 #![no_std]
-#![allow(non_snake_case)]
-#![allow(unused_attributes)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
-#![allow(unused_variables)]
 
 use register::mmio::{ReadOnly, ReadWrite};
 use register::{register_bitfields, Field};
@@ -350,7 +345,6 @@ impl Timer {
     }
 }
 
-#[allow(non_snake_case)]
 #[repr(C)]
 struct ISR {
 }

--- a/src/mainboard/ast/ast25x0/src/romstage/ramconst.rs
+++ b/src/mainboard/ast/ast25x0/src/romstage/ramconst.rs
@@ -1,9 +1,4 @@
 #![no_std]
-#![allow(non_snake_case)]
-#![allow(unused_attributes)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
-#![allow(unused_variables)]
 
 // u-bmc modified
 // Setting lifted from ast-g5-phy.h from OpenBMC u-boot

--- a/src/mainboard/ast/ast25x0/src/romstage/ramtable.rs
+++ b/src/mainboard/ast/ast25x0/src/romstage/ramtable.rs
@@ -1,9 +1,4 @@
 #![no_std]
-#![allow(non_snake_case)]
-#![allow(unused_attributes)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
-#![allow(unused_variables)]
 
 static TIME_TABLE_DDR3_1333: [u32; 17] = [
     0x53503C37, //       @ 0x010

--- a/src/mainboard/emulation/qemu-armv7/src/main.rs
+++ b/src/mainboard/emulation/qemu-armv7/src/main.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![no_main]
 #![feature(global_asm)]
+#![deny(warnings)]
 
 mod print;
 mod romstage;

--- a/src/mainboard/sifive/hifive/src/main.rs
+++ b/src/mainboard/sifive/hifive/src/main.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![no_main]
 #![feature(global_asm)]
+#![deny(warnings)]
 
 mod print;
 

--- a/src/mainboard/sifive/hifive/src/main.rs
+++ b/src/mainboard/sifive/hifive/src/main.rs
@@ -23,7 +23,7 @@ global_asm!(include_str!("../../../../../src/soc/sifive/fu540/src/init.S"));
 
 // TODO: For some reason, on hardware, a1 is not the address of the dtb, so we hard-code the device
 // tree here. TODO: The kernel ebreaks when given this device tree.
-const DTB: &'static [u8] = include_bytes!("hifive.dtb");
+//const DTB: &'static [u8] = include_bytes!("hifive.dtb");
 
 #[no_mangle]
 pub extern "C" fn _start(fdt_address: usize) -> ! {

--- a/src/soc/aspeed/ast2500/src/lib.rs
+++ b/src/soc/aspeed/ast2500/src/lib.rs
@@ -1,3 +1,4 @@
 #![no_std]
+#![deny(warnings)]
 
 pub mod reg;

--- a/src/soc/sifive/fu540/src/clock.rs
+++ b/src/soc/sifive/fu540/src/clock.rs
@@ -17,13 +17,13 @@
 //const FU540_BASE_FQY: usize = 33330;
 
 use clock::ClockNode;
-use core::{ops, ptr};
+use core::ops;
 use model::*;
 
 use crate::reg;
 use crate::is_qemu;
-use register::mmio::{ReadOnly, ReadWrite};
-use register::{register_bitfields, Field};
+use register::mmio::ReadWrite;
+use register::register_bitfields;
 
 #[repr(C)]
 

--- a/src/soc/sifive/fu540/src/clock.rs
+++ b/src/soc/sifive/fu540/src/clock.rs
@@ -16,7 +16,7 @@
  */
 
 // 33.33 Mhz after reset
-const FU540_BASE_FQY: usize = 33330;
+//const FU540_BASE_FQY: usize = 33330;
 
 use clock::ClockNode;
 use core::{ops, ptr};
@@ -170,7 +170,7 @@ impl<'a> Driver for Clock<'a> {
         /* nothing to do. */
     }
 
-    fn pread(&self, data: &mut [u8], _offset: usize) -> Result<usize> {
+    fn pread(&self, _data: &mut [u8], _offset: usize) -> Result<usize> {
         NOT_IMPLEMENTED
     }
 
@@ -189,29 +189,29 @@ impl<'a> Driver for Clock<'a> {
 
 //static struct prci_ctlr *prci = (void *)FU540_PRCI;
 
-const PRCI_CORECLK_MASK: u32 = 1;
-const PRCI_CORECLK_CORE_PLL: u32 = 0;
-const PRCI_CORECLK_HFCLK: u32 = 1;
+//const PRCI_CORECLK_MASK: u32 = 1;
+//const PRCI_CORECLK_CORE_PLL: u32 = 0;
+//const PRCI_CORECLK_HFCLK: u32 = 1;
 
-const PRCI_PLLCFG_LOCK: u32 = (1 << 31);
-const PRCI_PLLCFG_DIVR_SHIFT: u32 = 0;
-const PRCI_PLLCFG_DIVF_SHIFT: u32 = 6;
-const PRCI_PLLCFG_DIVQ_SHIFT: u32 = 15;
-const PRCI_PLLCFG_RANGE_SHIFT: u32 = 18;
-const PRCI_PLLCFG_BYPASS_SHIFT: u32 = 24;
-const PRCI_PLLCFG_FSE_SHIFT: u32 = 25;
-const PRCI_PLLCFG_DIVR_MASK: u32 = (0x03f << PRCI_PLLCFG_DIVR_SHIFT);
-const PRCI_PLLCFG_DIVF_MASK: u32 = (0x1ff << PRCI_PLLCFG_DIVF_SHIFT);
-const PRCI_PLLCFG_DIVQ_MASK: u32 = (0x007 << PRCI_PLLCFG_DIVQ_SHIFT);
-const PRCI_PLLCFG_RANGE_MASK: u32 = (0x07 << PRCI_PLLCFG_RANGE_SHIFT);
-const PRCI_PLLCFG_BYPASS_MASK: u32 = (0x1 << PRCI_PLLCFG_BYPASS_SHIFT);
-const PRCI_PLLCFG_FSE_MASK: u32 = (0x1 << PRCI_PLLCFG_FSE_SHIFT);
+//const PRCI_PLLCFG_LOCK: u32 = (1 << 31);
+//const PRCI_PLLCFG_DIVR_SHIFT: u32 = 0;
+//const PRCI_PLLCFG_DIVF_SHIFT: u32 = 6;
+//const PRCI_PLLCFG_DIVQ_SHIFT: u32 = 15;
+//const PRCI_PLLCFG_RANGE_SHIFT: u32 = 18;
+//const PRCI_PLLCFG_BYPASS_SHIFT: u32 = 24;
+//const PRCI_PLLCFG_FSE_SHIFT: u32 = 25;
+//const PRCI_PLLCFG_DIVR_MASK: u32 = (0x03f << PRCI_PLLCFG_DIVR_SHIFT);
+//const PRCI_PLLCFG_DIVF_MASK: u32 = (0x1ff << PRCI_PLLCFG_DIVF_SHIFT);
+//const PRCI_PLLCFG_DIVQ_MASK: u32 = (0x007 << PRCI_PLLCFG_DIVQ_SHIFT);
+//const PRCI_PLLCFG_RANGE_MASK: u32 = (0x07 << PRCI_PLLCFG_RANGE_SHIFT);
+//const PRCI_PLLCFG_BYPASS_MASK: u32 = (0x1 << PRCI_PLLCFG_BYPASS_SHIFT);
+//const PRCI_PLLCFG_FSE_MASK: u32 = (0x1 << PRCI_PLLCFG_FSE_SHIFT);
 
-const PRCI_DDRPLLCFG1_MASK: u32 = (1 << 31);
+//const PRCI_DDRPLLCFG1_MASK: u32 = (1 << 31);
 
-const PRCI_GEMGXLPPLCFG1_MASK: u32 = (1 << 31);
+//const PRCI_GEMGXLPPLCFG1_MASK: u32 = (1 << 31);
 
-const PRCI_CORECLKSEL_CORECLKSEL: u32 = 1;
+//const PRCI_CORECLKSEL_CORECLKSEL: u32 = 1;
 
 /* Clock initialization should only be done in romstage. */
 
@@ -298,7 +298,7 @@ impl<'a> Clock<'a> {
         // stuff before they come out of reset. So wait.
         // TODO: Add a register to read the current reset states, or DDR Control
         // device?
-        for i in 0..=255 {
+        for _ in 0..=255 {
             architecture::nop();
         }
         self.init_pll_ge();

--- a/src/soc/sifive/fu540/src/clock.rs
+++ b/src/soc/sifive/fu540/src/clock.rs
@@ -100,7 +100,7 @@ register_bitfields! {
 // Or possibly a varargs of enums. Whatever.
 fn reset_mask(ddr: bool, axi: bool, ahb: bool, phy: bool, ge: bool) -> u32 {
     // The default is to reset nothing.
-    let mut m = ReadWrite::<u32, ResetCtl::Register>::new(0x2f);
+    let m = ReadWrite::<u32, ResetCtl::Register>::new(0x2f);
     if ddr {
         m.modify(ResetCtl::DDRCtl.val(0));
     }
@@ -120,7 +120,7 @@ fn reset_mask(ddr: bool, axi: bool, ahb: bool, phy: bool, ge: bool) -> u32 {
 }
 
 fn default_core() -> u32 {
-    let mut r = ReadWrite::<u32, PLLCfg0::Register>::new(0);
+    let r = ReadWrite::<u32, PLLCfg0::Register>::new(0);
     r.modify(PLLCfg0::DivR.val(0));
     r.modify(PLLCfg0::DivF.val(59));
     r.modify(PLLCfg0::DivQ.val(2));
@@ -130,7 +130,7 @@ fn default_core() -> u32 {
     r.get()
 }
 fn default_ddr() -> u32 {
-    let mut r = ReadWrite::<u32, PLLCfg0::Register>::new(0);
+    let r = ReadWrite::<u32, PLLCfg0::Register>::new(0);
     r.modify(PLLCfg0::DivR.val(0));
     r.modify(PLLCfg0::DivF.val(55));
     r.modify(PLLCfg0::DivQ.val(2));
@@ -140,7 +140,7 @@ fn default_ddr() -> u32 {
     r.get()
 }
 fn default_ge() -> u32 {
-    let mut r = ReadWrite::<u32, PLLCfg0::Register>::new(0);
+    let r = ReadWrite::<u32, PLLCfg0::Register>::new(0);
     r.modify(PLLCfg0::DivR.val(0));
     r.modify(PLLCfg0::DivF.val(59));
     r.modify(PLLCfg0::DivQ.val(5));

--- a/src/soc/sifive/fu540/src/clock.rs
+++ b/src/soc/sifive/fu540/src/clock.rs
@@ -1,5 +1,3 @@
-#![feature(asm)]
-#![feature(global_asm)]
 /*
  * This file is part of the coreboot project.
  *

--- a/src/soc/sifive/fu540/src/clock.rs
+++ b/src/soc/sifive/fu540/src/clock.rs
@@ -27,7 +27,6 @@ use crate::is_qemu;
 use register::mmio::{ReadOnly, ReadWrite};
 use register::{register_bitfields, Field};
 
-#[allow(non_snake_case)]
 #[repr(C)]
 
 pub struct RegisterBlock {

--- a/src/soc/sifive/fu540/src/ddr.rs
+++ b/src/soc/sifive/fu540/src/ddr.rs
@@ -4,8 +4,8 @@ use model::*;
 use crate::reg;
 use crate::ux00;
 use crate::is_qemu;
-use register::mmio::{ReadOnly, ReadWrite};
-use register::{register_bitfields, Field};
+use register::mmio::ReadWrite;
+use register::register_bitfields;
 use core::convert::TryInto;
 
 #[repr(C)]

--- a/src/soc/sifive/fu540/src/ddr.rs
+++ b/src/soc/sifive/fu540/src/ddr.rs
@@ -11,7 +11,7 @@ use core::convert::TryInto;
 #[repr(C)]
 
 pub struct BlockerRegister {
-    Blocker: ReadWrite<u64, Blocker::Register>,
+    blocker: ReadWrite<u64, Blocker::Register>,
 }
 
 // so what I'd really like to do, given that we can have some control over deref,
@@ -20,17 +20,17 @@ pub struct BlockerRegister {
 // For now, we won't really use this. We have working coreboot code and we'll transition
 // one ugly bit at a time. DDR is very sensitive to simple errors.
 pub struct RegisterBlock {
-    CR0: ReadWrite<u64, CR0::Register>,
+    cr0: ReadWrite<u64, CR0::Register>,
     _2: [u32; 18],
-    CR19: ReadWrite<u64, CR19::Register>,
+    cr19: ReadWrite<u64, CR19::Register>,
     _3: [u32; 1],
-    CR21: ReadWrite<u64, CR21::Register>,
+    cr21: ReadWrite<u64, CR21::Register>,
     _4: [u32; 98],
-    CR120: ReadWrite<u64, CR120::Register>,
+    cr120: ReadWrite<u64, CR120::Register>,
     _5: [u32; 11],
-    CR132: ReadWrite<u64, CR132::Register>,
+    cr132: ReadWrite<u64, CR132::Register>,
     _6: [u32; 3],
-    CR136: ReadWrite<u64, CR136::Register>,
+    cr136: ReadWrite<u64, CR136::Register>,
     _7: [u32; 0x800 - 127],
 }
 
@@ -70,7 +70,7 @@ impl Driver for DDR {
         match data {
             b"on" => {
                 sdram_init();
-                Ok(MemSize().try_into().unwrap())
+                Ok(mem_size().try_into().unwrap())
             },
             _ => Ok(0),
         }
@@ -238,7 +238,7 @@ fn sdram_init() {
 
     ux00::ux00ddr_mask_mc_init_complete_interrupt();
     ux00::ux00ddr_mask_outofrange_interrupts();
-    let ddr_size: u64 = MemSize();
+    let ddr_size: u64 = mem_size();
     ux00::ux00ddr_setuprangeprotection(ddr_size);
     ux00::ux00ddr_mask_port_command_error_interrupt();
 
@@ -249,7 +249,7 @@ fn sdram_init() {
     ux00::ux00ddr_phy_fixup();
 }
 
-pub fn MemSize() -> u64 {
+pub fn mem_size() -> u64 {
     if is_qemu() {
         return 1*1024*1024*1024
     }

--- a/src/soc/sifive/fu540/src/ddr.rs
+++ b/src/soc/sifive/fu540/src/ddr.rs
@@ -8,7 +8,6 @@ use register::mmio::{ReadOnly, ReadWrite};
 use register::{register_bitfields, Field};
 use core::convert::TryInto;
 
-#[allow(non_snake_case)]
 #[repr(C)]
 
 pub struct BlockerRegister {

--- a/src/soc/sifive/fu540/src/ddr.rs
+++ b/src/soc/sifive/fu540/src/ddr.rs
@@ -20,17 +20,17 @@ pub struct BlockerRegister {
 // For now, we won't really use this. We have working coreboot code and we'll transition
 // one ugly bit at a time. DDR is very sensitive to simple errors.
 pub struct RegisterBlock {
-    cr0: ReadWrite<u64, CR0::Register>,
+    _cr0: ReadWrite<u64, CR0::Register>,
     _2: [u32; 18],
-    cr19: ReadWrite<u64, CR19::Register>,
+    _cr19: ReadWrite<u64, CR19::Register>,
     _3: [u32; 1],
-    cr21: ReadWrite<u64, CR21::Register>,
+    _cr21: ReadWrite<u64, CR21::Register>,
     _4: [u32; 98],
-    cr120: ReadWrite<u64, CR120::Register>,
+    _cr120: ReadWrite<u64, CR120::Register>,
     _5: [u32; 11],
-    cr132: ReadWrite<u64, CR132::Register>,
+    _cr132: ReadWrite<u64, CR132::Register>,
     _6: [u32; 3],
-    cr136: ReadWrite<u64, CR136::Register>,
+    _cr136: ReadWrite<u64, CR136::Register>,
     _7: [u32; 0x800 - 127],
 }
 
@@ -62,7 +62,7 @@ impl Driver for DDR {
         /* nothing to do. */
     }
 
-    fn pread(&self, data: &mut [u8], _offset: usize) -> Result<usize> {
+    fn pread(&self, _data: &mut [u8], _offset: usize) -> Result<usize> {
         NOT_IMPLEMENTED
     }
 

--- a/src/soc/sifive/fu540/src/ddrregs.rs
+++ b/src/soc/sifive/fu540/src/ddrregs.rs
@@ -2,8 +2,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 /* See the file LICENSE for further information */
-#![no_std]
-
 use crate::ctl;
 use crate::phy;
 

--- a/src/soc/sifive/fu540/src/ddrregs.rs
+++ b/src/soc/sifive/fu540/src/ddrregs.rs
@@ -7,7 +7,7 @@
 use crate::ctl;
 use crate::phy;
 
-pub static DenaliPhyData: [u32; 1215] = [
+pub static DENALI_PHY_DATA: [u32; 1215] = [
     phy::DENALI_PHY_00_DATA,
     phy::DENALI_PHY_01_DATA,
     phy::DENALI_PHY_02_DATA,
@@ -1225,7 +1225,7 @@ pub static DenaliPhyData: [u32; 1215] = [
     phy::DENALI_PHY_1214_DATA,
 ];
 
-pub static DenaliCtlData: [u32; 265] = [
+pub static DENALI_CTL_DATA: [u32; 265] = [
     ctl::DENALI_CTL_00_DATA,
     ctl::DENALI_CTL_01_DATA,
     ctl::DENALI_CTL_02_DATA,

--- a/src/soc/sifive/fu540/src/lib.rs
+++ b/src/soc/sifive/fu540/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(warnings)]
 
 pub mod clock;
 pub mod ctl;

--- a/src/soc/sifive/fu540/src/ux00.rs
+++ b/src/soc/sifive/fu540/src/ux00.rs
@@ -202,13 +202,13 @@ pub fn ux00ddr_phy_fixup() -> u64 {
         let regbase: u32 = slicebase + 34;
         for reg in 0..4 {
             // what the hell?
-            let updownreg: u32 = peek(ddrphyreg, (regbase + reg));
+            let updownreg: u32 = peek(ddrphyreg, regbase + reg);
             for bit in 0..2 {
                 let phy_rx_cal_dqn_0_offset = if bit == 0 { PHY_RX_CAL_DQ0_0_OFFSET } else { PHY_RX_CAL_DQ1_0_OFFSET };
                 let down: u32 = (updownreg >> phy_rx_cal_dqn_0_offset) & 0x3F;
                 let up: u32 = (updownreg >> (phy_rx_cal_dqn_0_offset + 6)) & 0x3F;
-                let failc0: bool = ((down == 0) && (up == 0x3F));
-                let failc1: bool = ((up == 0) && (down == 0x3F));
+                let failc0: bool = (down == 0) && (up == 0x3F);
+                let failc1: bool = (up == 0) && (down == 0x3F);
 
                 // print error message on failure
                 if failc0 || failc1 {

--- a/src/soc/sifive/fu540/src/ux00.rs
+++ b/src/soc/sifive/fu540/src/ux00.rs
@@ -194,10 +194,10 @@ pub fn ux00ddr_phy_fixup() -> u64 {
 
     let ddrphyreg: u32 = reg::DDR_CTRL + 0x2000;
 
-    let mut fails: u64 = 0;
+    //let mut fails: u64 = 0;
     let mut slicebase: u32 = 0;
     let mut dq: u32 = 0;
-    for slice in 0..8 {
+    for _ in 0..8 {
         // check errata condition
         let regbase: u32 = slicebase + 34;
         for reg in 0..4 {
@@ -219,11 +219,11 @@ pub fn ux00ddr_phy_fixup() -> u64 {
                 if failc0 || failc1 {
                     // good news: we can use fmt; skip this nonsense.
                     //if (fails==0) uart_puts((void*) UART0_CTRL_ADDR, "DDR error in fixing up \n");
-                    fails |= (1 << dq);
-                    let mut slicelsc: u8 = 48;
-                    let mut slicemsc: u8 = 48;
-                    slicelsc += (dq % 10) as u8;
-                    slicemsc += (dq / 10) as u8;
+                    //fails |= (1 << dq);
+                    //let mut slicelsc: u8 = 48;
+                    //let mut slicemsc: u8 = 48;
+                    //slicelsc += (dq % 10) as u8;
+                    //slicemsc += (dq / 10) as u8;
                     //uart_puts((void*) UART0_CTRL_ADDR, "S ");
                     //uart_puts((void*) UART0_CTRL_ADDR, &slicemsc);
                     //uart_puts((void*) UART0_CTRL_ADDR, &slicelsc);

--- a/src/soc/sifive/fu540/src/ux00.rs
+++ b/src/soc/sifive/fu540/src/ux00.rs
@@ -204,12 +204,7 @@ pub fn ux00ddr_phy_fixup() -> u64 {
             // what the hell?
             let updownreg: u32 = peek(ddrphyreg, (regbase + reg));
             for bit in 0..2 {
-                let mut phy_rx_cal_dqn_0_offset: u64;
-                if bit == 0 {
-                    phy_rx_cal_dqn_0_offset = PHY_RX_CAL_DQ0_0_OFFSET;
-                } else {
-                    phy_rx_cal_dqn_0_offset = PHY_RX_CAL_DQ1_0_OFFSET;
-                }
+                let phy_rx_cal_dqn_0_offset = if bit == 0 { PHY_RX_CAL_DQ0_0_OFFSET } else { PHY_RX_CAL_DQ1_0_OFFSET };
                 let down: u32 = (updownreg >> phy_rx_cal_dqn_0_offset) & 0x3F;
                 let up: u32 = (updownreg >> (phy_rx_cal_dqn_0_offset + 6)) & 0x3F;
                 let failc0: bool = ((down == 0) && (up == 0x3F));

--- a/src/soc/sifive/fu540/src/ux00.rs
+++ b/src/soc/sifive/fu540/src/ux00.rs
@@ -36,38 +36,38 @@ pub const PHY_RX_CAL_DQ1_0_OFFSET: u64 = 16;
 
 // This is a 64-bit machine but all this action seems to be on 32-bit values.
 // No idea why this is.
-// Index is a word offset.
-fn poke(Pointer: u32, Index: u32, Value: u32) -> () {
-    let addr = (Pointer + (Index << 2)) as *mut u32;
+// index is a word offset.
+fn poke(pointer: u32, index: u32, value: u32) -> () {
+    let addr = (pointer + (index << 2)) as *mut u32;
     unsafe {
-        ptr::write_volatile(addr, Value);
+        ptr::write_volatile(addr, value);
     }
 }
 
-fn poke64(Pointer: u32, Index: u32, Value: u64) -> () {
-    let addr = (Pointer + (Index << 2)) as *mut u64;
-    //let addr1 = (Pointer + (Index << 2) + 4) as *mut u32;
+fn poke64(pointer: u32, index: u32, value: u64) -> () {
+    let addr = (pointer + (index << 2)) as *mut u64;
+    //let addr1 = (pointer + (index << 2) + 4) as *mut u32;
     unsafe {
-        ptr::write_volatile(addr, Value);
-        //let v2: u32 = (Value) as u32;
+        ptr::write_volatile(addr, value);
+        //let v2: u32 = (value) as u32;
         //ptr::write_volatile(addr1, v2);
-        //let v1: u32 = (Value >> 32) as u32;
+        //let v1: u32 = (value >> 32) as u32;
         //ptr::write_volatile(addr, v1);
     }
 }
 
-fn set(Pointer: u32, Index: u32, Value: u32) -> () {
-    let v = peek(Pointer, Index);
-    poke(Pointer, Index, v | Value);
+fn set(pointer: u32, index: u32, value: u32) -> () {
+    let v = peek(pointer, index);
+    poke(pointer, index, v | value);
 }
 
-fn clr(Pointer: u32, Index: u32, Value: u32) -> () {
-    let v = peek(Pointer, Index);
-    poke(Pointer, Index, v & Value);
+fn clr(pointer: u32, index: u32, value: u32) -> () {
+    let v = peek(pointer, index);
+    poke(pointer, index, v & value);
 }
 
-fn peek(Pointer: u32, Index: u32) -> u32 {
-    let addr = (Pointer + (Index << 2)) as *const u32;
+fn peek(pointer: u32, index: u32) -> u32 {
+    let addr = (pointer + (index << 2)) as *const u32;
     unsafe { ptr::read_volatile(addr) }
 }
 
@@ -75,14 +75,14 @@ fn peek(Pointer: u32, Index: u32) -> u32 {
 
 pub fn phy_reset() {
     for i in 1152..=1214 {
-        poke(reg::DDR_PHY, i as u32, ddrregs::DenaliPhyData[i]);
-        //u32 physet = DenaliPhyData[i];
+        poke(reg::DDR_PHY, i as u32, ddrregs::DENALI_PHY_DATA[i]);
+        //u32 physet = DENALI_PHY_DATA[i];
         // /*if (physet!=0)*/ DDR_PHY[i] = physet;
     }
     for i in 0..=1151 {
-        poke(reg::DDR_PHY, i as u32, ddrregs::DenaliPhyData[i]);
+        poke(reg::DDR_PHY, i as u32, ddrregs::DENALI_PHY_DATA[i]);
         //for (i=0;i<=1151;i++) {
-        //    u32 physet = DenaliPhyData[i];
+        //    u32 physet = DENALI_PHY_DATA[i];
         //if (physet!=0)*/ DDR_PHY[i] = physet;
     }
 }
@@ -90,8 +90,8 @@ pub fn phy_reset() {
 pub fn ux00ddr_writeregmap() {
     for i in 0..=264 {
         //  for (i=0;i<=264;i++) {
-        poke(reg::DDR_CTRL, i as u32, ddrregs::DenaliCtlData[i]);
-        // u32 ctlset = DenaliCtlData[i];
+        poke(reg::DDR_CTRL, i as u32, ddrregs::DENALI_CTL_DATA[i]);
+        // u32 ctlset = DENALI_CTL_DATA[i];
         // /*if (ctlset!=0)*/ DDR_CTRL[i] = ctlset;
     }
 
@@ -147,8 +147,8 @@ pub fn ux00ddr_mask_leveling_completed_interrupt() {
 
 pub fn ux00ddr_setuprangeprotection(end_addr: u64) {
     poke(reg::DDR_CTRL, 209, 0x0);
-    let end_addr_16Kblocks: u32 = (((end_addr >> 14) & 0x7FFFFF) - 1) as u32;
-    poke(reg::DDR_CTRL, 210, end_addr_16Kblocks);
+    let end_addr_16k_blocks: u32 = (((end_addr >> 14) & 0x7FFFFF) - 1) as u32;
+    poke(reg::DDR_CTRL, 210, end_addr_16k_blocks);
     poke(reg::DDR_CTRL, 212, 0x0);
     poke(reg::DDR_CTRL, 214, 0x0);
     poke(reg::DDR_CTRL, 216, 0x0);

--- a/tools/layoutflash/src/main.rs
+++ b/tools/layoutflash/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(slice_patterns)]
+#![deny(warnings)]
 use device_tree::{infer_type, Entry, FdtReader, Type, MAX_NAME_SIZE};
 use model::Driver;
 use wrappers::SliceReader;


### PR DESCRIPTION
Currently we get blasted by pages of warnings during compilation, so this fixes all of them and turns warnings into errors to prevent them from happening again. In particular, the compiler will now insist on Rust naming conventions and flag any unused variables/imports/attributes.