### PR TITLE
hifive: Print PanicInfo in panic_handler

### DIFF
--- a/src/arch/riscv/rv64/src/lib.rs
+++ b/src/arch/riscv/rv64/src/lib.rs
@@ -4,20 +4,12 @@
 #![feature(global_asm)]
 #![deny(warnings)]
 
-use core::panic::PanicInfo;
-
 pub fn halt() -> ! {
     loop {
         // Bug with LLVM marks empty loops as undefined behaviour.
         // See: https://github.com/rust-lang/rust/issues/28728
         unsafe { asm!("wfi" :::: "volatile") }
     }
-}
-
-/// This function is called on panic.
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    halt()
 }
 
 pub fn fence() {


### PR DESCRIPTION
This makes the panic_handler SOC-specific because it needs to know a
thing about UART.

Tested by placing the following in _start:

	Result::<(), _>::Err("2 + 2 = 5").unwrap();

The panic looks something like:

	PANIC: panicked at 'called `Result::unwrap()` on an `Err` value: "2 + 2 = 5"', /home/ryan/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/result.rs:1084:5

Too bad the line number is not very useful (and probably makes the
binaries non-reproducible).

The size of the bootblob increases from 31K to 36K.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>