### PR TITLE
lib/device_tree: Check if the string is UTF8

### DIFF
--- a/src/lib/device_tree/src/lib.rs
+++ b/src/lib/device_tree/src/lib.rs
@@ -203,7 +203,10 @@ pub fn infer_type(data: &[u8]) -> Type {
     }
     if let Some(i) = data.iter().position(|&c| !is_print(c)) {
         if i == data.len() - 1 && data[i] == 0 {
-            return Type::String(unsafe { core::str::from_utf8_unchecked(&data[..data.len() - 1]) });
+            match core::str::from_utf8(&data[..data.len() - 1]) {
+                Ok(ret) => return Type::String(ret),
+                Err(_e) => {  },
+            }
         }
     }
     if data.len() == 4 {
@@ -216,5 +219,5 @@ pub fn infer_type(data: &[u8]) -> Type {
 }
 
 fn is_print(c: u8) -> bool {
-    0x20 <= c && c < 0xff
+    0x20 <= c && c < 0x7f
 }


### PR DESCRIPTION
Instead of blindly converting any data with the first byte between 0x20
and 0xff into a string let's safely see if it is valid UTF8 string.

This fixes the strange print being seen when printing the QEMU device
tree clock-frequency. This also removes ome unsafe code!

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>