### PR TITLE
azure-pipelines.yml: Use a new QEMU branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,8 +26,7 @@ steps:
   displayName: 'Build for RISC-V'
 - script: |
     set -e
-    git clone https://github.com/qemu/qemu && cd qemu
-    git apply ../tools/soc/sifive/fu540/qemu.diff
+    git clone https://github.com/alistair23/qemu.git -b mainline/alistair/board-memory.next && cd qemu
     mkdir build-riscv64 && cd build-riscv64
     ../configure --target-list=riscv64-softmmu
     make -j16


### PR DESCRIPTION
The current diff does not apply to the latest master QEMU. Instead of
updating the diff let's base the testing on my branch which is being
sent to upstream QEMU.

Once the patches are in upstream QEMU we can remove all the
modifications to QEMU in the testing and documentation. For now let's
leave everything else as is and do the bare minimum to get the tests
running.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>