### PR TITLE
Fix azure pipelines patch to qemu by checking out known-good ref of qemu

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ steps:
   displayName: 'Build for RISC-V'
 - script: |
     set -e
-    git clone https://github.com/qemu/qemu && cd qemu
+    git clone https://github.com/qemu/qemu && cd qemu && git checkout 46517dd4971fc1fdd5b379e72cc377626ad98160
     git apply ../tools/soc/sifive/fu540/qemu.diff
     mkdir build-riscv64 && cd build-riscv64
     ../configure --target-list=riscv64-softmmu


### PR DESCRIPTION
The messages are a bit more verbose but it is still better than
things like

error 2

which we got before