### PR TITLE
fu540 init: add a hack for broken rust riscv runtime

### DIFF
--- a/src/soc/sifive/fu540/src/init.S
+++ b/src/soc/sifive/fu540/src/init.S
@@ -1,3 +1,13 @@
+// This is a GROSS HACK until rust is fixed to not expect
+// atomic load store on 16 bit quantities, which riscv
+// can not do.
+.globl __atomic_store_16
+__atomic_store_16:
+	ret
+.globl __atomic_load_16
+__atomic_load_16:
+	ret
+// END GROSS HACK
 
 .globl _stack_ptr
 .section .rodata


### PR DESCRIPTION
For now, rust runtime is broken as it demands 16 bit atomic
load and store ops, which riscv can not do.

Add a gross hack to get us building again until they fix their
code.

This allows me to run again.

Arguably, this belongs in arch, but since it should not exist
at all, and I don't want to add more .S files, it goes here.

We'll revert it very soon.