### PR TITLE
Revert "fu540 init: add a hack for broken rust riscv runtime"

### DIFF
--- a/src/soc/sifive/fu540/src/init.S
+++ b/src/soc/sifive/fu540/src/init.S
@@ -1,13 +1,3 @@
-// This is a GROSS HACK until rust is fixed to not expect
-// atomic load store on 16 bit quantities, which riscv
-// can not do.
-.globl __atomic_store_16
-__atomic_store_16:
-	ret
-.globl __atomic_load_16
-__atomic_load_16:
-	ret
-// END GROSS HACK
 
 .globl _stack_ptr
 .section .rodata


### PR DESCRIPTION
Fixed by https://github.com/rust-lang/compiler-builtins/pull/324

This reverts commit f506d39cebf198d0bf2503cac99880ca947e6b6e.