### PR TITLE
Add the rv32

### DIFF
--- a/src/arch/riscv/rv32/Cargo.toml
+++ b/src/arch/riscv/rv32/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "architecture"
+version = "0.1.0"
+authors = ["Oreboot Authors"]
+edition = "2018"
+
+[profile.release]
+opt-level = 'z'  # Optimize for size.

--- a/src/arch/riscv/rv32/src/lib.rs
+++ b/src/arch/riscv/rv32/src/lib.rs
@@ -1,0 +1,22 @@
+#![feature(asm)]
+#![feature(lang_items, start)]
+#![no_std]
+#![feature(global_asm)]
+#![deny(warnings)]
+
+pub fn halt() -> ! {
+    loop {
+        // Bug with LLVM marks empty loops as undefined behaviour.
+        // See: https://github.com/rust-lang/rust/issues/28728
+        unsafe { asm!("wfi" :::: "volatile") }
+    }
+}
+
+pub fn fence() {
+    unsafe { asm!("fence" :::: "volatile") }
+}
+
+pub fn nop() {
+    unsafe { asm!("nop" :::: "volatile") }
+}
+

--- a/src/arch/riscv/rv32/src/mod.rs
+++ b/src/arch/riscv/rv32/src/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "rv32")]
+pub mod lib;
+pub mod reg;
+

--- a/src/arch/riscv/rv32/src/reg.rs
+++ b/src/arch/riscv/rv32/src/reg.rs
@@ -1,0 +1,2 @@
+const PageSize: u32 = 4096;
+const PageShift: u32 = 12;


### PR DESCRIPTION
There are lots of options, e.g. imc vs. imac, so we should try to keep this code clean
of all the variants. That should likely be amended by the SOC.