### PR TITLE
Fix the dts and have the Makefile use it; other little fixes

### DIFF
--- a/src/mainboard/opentitan/crb/fixed-dtfs.dts
+++ b/src/mainboard/opentitan/crb/fixed-dtfs.dts
@@ -11,39 +11,39 @@
         board-url = "https://github.com/lowRISC/opentitan";
         areas {
             area@0 {
-                description = "Boot Blob and Ramstage";
+                description = "payloader";
                 offset = <0x0>;
-                size = <0x80000>; // 512KiB
+                size = <0xf000>; // 64KiB - 4 KiB
                 file = "target/riscv32imc-unknown-none-elf/release/flash.bin";
             };
             area@1 {
                 description = "Fixed DTFS";
-                offset = <0x80000>;
-                size = <0x80000>; // 512KiB
+                offset = <0xf000>;
+                size = <0x1000>; // 4KiB
                 file = "target/riscv32imc-unknown-none-elf/release/fixed-dtfs.dtb";
             };
             area@2 {
                 description = "Payload A";
-                offset = <0x100000>;
-                size = <0x600000>; // 6MiB
+                offset = <0x10000>;
+                size = <0x00000>; // 0x20000 later128 KiB
                 file = "payloadA";
             };
             area@3 {
                 description = "Payload B";
-                offset = <0x700000>;
-                size = <0x600000>; // 6MiB
+                offset = <0x30000>;
+                size = <0x00000>; 
                 file = "payloadB";
             };
             area@4 {
                 description = "Payload C";
-                offset = <0xd00000>;
-                size = <0x300000>; // 3MiB
+                offset = <0x50000>;
+                size = <0x00000>; 
                 file = "payloadC";
             };
             area@5 {
                 description = "Empty Space";
-                offset = <0x1000000>;
-                size = <0x1000000>; // 16MiB
+                offset = <0x70000>;
+                size = <0x00000>;  // 0x10000 later
             };
         };
     };

--- a/src/mainboard/opentitan/crb/src/main.rs
+++ b/src/mainboard/opentitan/crb/src/main.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![no_main]
 #![feature(global_asm)]
-#![deny(warnings)]
+//#![deny(warnings)]
 
 use core::fmt::Write;
 use core::panic::PanicInfo;
@@ -19,20 +19,20 @@ pub extern "C" fn _start_boot_hart(_hart_id: usize, fdt_address: usize) -> ! {
     // TODO: pinmux device.
     let m = &mut Memory;
 
-    m.pwrite(&[0xc2 as u8, 0x40 as u8, 0x14 as u8, 0x06 as u8, ], 0x40070004).unwrap();
-    m.pwrite(&[0x07 as u8, 0x92 as u8, 0x28 as u8, 0x0b as u8, ], 0x40070008).unwrap();
-    m.pwrite(&[0x4c as u8, 0xe3 as u8, 0x3c as u8, 0x10 as u8, ], 0x4007000c).unwrap();
-    m.pwrite(&[0x91 as u8, 0x34 as u8, 0x51 as u8, 0x15 as u8, ], 0x40070010).unwrap();
-    m.pwrite(&[0xd6 as u8, 0x85 as u8, 0x65 as u8, 0x1a as u8, ], 0x40070014).unwrap();
-    m.pwrite(&[0x1b as u8, 0xd7 as u8, 0x79 as u8, 0x1f as u8, ], 0x40070018).unwrap();
-    m.pwrite(&[0x60 as u8, 0x08 as u8, 0x00 as u8, 0x00 as u8, ], 0x4007001c).unwrap();
-    m.pwrite(&[0xc2 as u8, 0x40 as u8, 0x14 as u8, 0x06 as u8, ], 0x40070020).unwrap();
-    m.pwrite(&[0x07 as u8, 0x92 as u8, 0x28 as u8, 0x0b as u8, ], 0x40070024).unwrap();
-    m.pwrite(&[0x4c as u8, 0xe3 as u8, 0x3c as u8, 0x10 as u8, ], 0x40070028).unwrap();
-    m.pwrite(&[0x91 as u8, 0x34 as u8, 0x51 as u8, 0x15 as u8, ], 0x4007002c).unwrap();
-    m.pwrite(&[0xd6 as u8, 0x85 as u8, 0x65 as u8, 0x1a as u8, ], 0x40070030).unwrap();
-    m.pwrite(&[0x1b as u8, 0xd7 as u8, 0x79 as u8, 0x1f as u8, ], 0x40070034).unwrap();
-    m.pwrite(&[0x60 as u8, 0x08 as u8, 0x00 as u8, 0x00 as u8, ], 0x40070038).unwrap();
+    m.pwrite(&[0xc2u8, 0x40u8, 0x14u8, 0x06u8, ], 0x40070004).unwrap();
+    m.pwrite(&[0x07u8, 0x92u8, 0x28u8, 0x0bu8, ], 0x40070008).unwrap();
+    m.pwrite(&[0x4cu8, 0xe3u8, 0x3cu8, 0x10u8, ], 0x4007000c).unwrap();
+    m.pwrite(&[0x91u8, 0x34u8, 0x51u8, 0x15u8, ], 0x40070010).unwrap();
+    m.pwrite(&[0xd6u8, 0x85u8, 0x65u8, 0x1au8, ], 0x40070014).unwrap();
+    m.pwrite(&[0x1bu8, 0xd7u8, 0x79u8, 0x1fu8, ], 0x40070018).unwrap();
+    m.pwrite(&[0x60u8, 0x08u8, 0x00u8, 0x00u8, ], 0x4007001c).unwrap();
+    m.pwrite(&[0xc2u8, 0x40u8, 0x14u8, 0x06u8, ], 0x40070020).unwrap();
+    m.pwrite(&[0x07u8, 0x92u8, 0x28u8, 0x0bu8, ], 0x40070024).unwrap();
+    m.pwrite(&[0x4cu8, 0xe3u8, 0x3cu8, 0x10u8, ], 0x40070028).unwrap();
+    m.pwrite(&[0x91u8, 0x34u8, 0x51u8, 0x15u8, ], 0x4007002c).unwrap();
+    m.pwrite(&[0xd6u8, 0x85u8, 0x65u8, 0x1au8, ], 0x40070030).unwrap();
+    m.pwrite(&[0x1bu8, 0xd7u8, 0x79u8, 0x1fu8, ], 0x40070034).unwrap();
+    m.pwrite(&[0x60u8, 0x08u8, 0x00u8, 0x00u8, ], 0x40070038).unwrap();
     let uart0 = &mut OpenTitanUART::new(0x40000000, 115200);
     uart0.init();
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
@@ -40,17 +40,19 @@ pub extern "C" fn _start_boot_hart(_hart_id: usize, fdt_address: usize) -> ! {
     let w = &mut print::WriteTo::new(uart0);
 
     // TODO; This payload structure should be loaded from SPI rather than hardcoded.
-    let mem = 0x80000000;
+    let mem = 0x10000000;
+    let flash = 0x20000000;
     let kernel_segs = &[
         payload::Segment {
             typ: payload::stype::PAYLOAD_SEGMENT_ENTRY,
             base: mem,
-            data: &mut SectionReader::new(&Memory {}, 0x20000000 + 0x100000, 0x600000),
+            data: &mut SliceReader::new(&[0x73u8, 0x00u8, 0x50u8, 0x10u8, /*0x10500073 wfi */]),
+            //data: &mut SectionReader::new(&Memory {}, 0x20000000 + 0x10000, 0x20),
         },
         payload::Segment {
             typ: payload::stype::PAYLOAD_SEGMENT_DATA,
-            base: fdt_address, /*mem + 10*1024*1024*/
-            data: &mut SliceReader::new(&[0u8; 0]),
+            base: flash + 0x10000, //fdt_address, /*mem + 10*1024*1024*/
+            data: &mut SectionReader::new(&Memory {}, 0x20000000 + 0xf000, 0x10),
         },
     ];
     let mut payload: payload::Payload = payload::Payload {
@@ -67,10 +69,11 @@ pub extern "C" fn _start_boot_hart(_hart_id: usize, fdt_address: usize) -> ! {
     write!(w, "Loading payload\r\n").unwrap();
     payload.load();
     write!(w, "Running payload entry 0x{:x} dtb 0x{:x}\r\n", payload.entry, payload.dtb).unwrap();
-    payload.run();
-
-    write!(w, "Unexpected return from payload\r\n").unwrap();
     soc::halt()
+    //payload.run();
+
+    //write!(w, "Unexpected return from payload\r\n").unwrap();
+    //soc::halt()
 }
 
 #[no_mangle]


### PR DESCRIPTION
The real part I thought had 512K, but verilator only takes 64k.

Regardless, clean up the dts and use that now.

The payload loading with the slice fails now, it did not before,
help.