### PR TITLE
In-place sed for debug fixed-dtfs.dts

### DIFF
--- a/src/mainboard/sifive/hifive/Makefile.toml
+++ b/src/mainboard/sifive/hifive/Makefile.toml
@@ -5,14 +5,17 @@ skip_core_tasks = true
 [env.development]
 CARGO_ARGS = "--verbose"
 TARGET_DIR = "target/riscv64imac-unknown-none-elf/debug"
+DTS_SED_INPLACE = "s#/release/#/debug/#"
 
 [env.release]
 CARGO_ARGS = "--release --verbose"
 TARGET_DIR = "target/riscv64imac-unknown-none-elf/release"
+DTS_SED_INPLACE = "s#/debug/#/release/#"
 
 [tasks.default]
 dependencies = ["bootblob"]
 script = [
+	"sed -i \"${DTS_SED_INPLACE}\" fixed-dtfs.dts",
 	"dtc fixed-dtfs.dts -O dtb -o ${TARGET_DIR}/fixed-dtfs.dtb",
 	"layoutflash ${TARGET_DIR}/fixed-dtfs.dtb ${TARGET_DIR}/oreboot.bin",
 ]


### PR DESCRIPTION
**What:**

* Fixes #135 by inserting the `sed` suggested by @rjoleary, and it’s inverse, into `Makefile.toml`.
* `s#/release/#/debug/#` instead of `s/release/debug/`, to only do the replacement if word is within a path, in case there’s intentional uses of these words in the DTFS going forward (your use of the Device Tree is…interesting :wink:).

**Why:**

To address the comment about the value of debug on #135: the default debug profile includes `overflow-checks = true`, so the target will panic on integer overflow where the developer hasn’t made it explicit (e.g. [u32::wrapping_add](https://doc.rust-lang.org/std/primitive.u32.html#method.wrapping_add)). Release mode will silently allow wrap-around to happen, like C/C++. This may make a debug target worth keeping around, maybe there are other reasons – not too familiar as I’m new to Rust.

**Caveat:**

There is a risk of creating "thrashing" in the git history for `fixed-dtfs.dts` if developer A builds debug, pushes updated `fixed-dtfs.dts`, developer B clones and builds release, pushes updated `fixed-dtfs.dts`, etc. But IMO this isn’t a major drawback and is preferable to the current state (following along with the [build instructions](https://github.com/oreboot/oreboot#building-oreboot) fails for first-time users!).

**Next:**

Update `Makefile.toml` files for other targets, as appropriate, if this solution is desirable – your call.