### PR TITLE
Fix oreboot on opentitan (earlgrey)

### DIFF
--- a/src/mainboard/opentitan/crb/Makefile.toml
+++ b/src/mainboard/opentitan/crb/Makefile.toml
@@ -19,7 +19,7 @@ script = [
 	"dd if=${TARGET_DIR}/bootblob.bin of=${TARGET_DIR}/flash.bin ibs=32768 count=1 skip=16383",
 	"dtc fixed-dtfs.dts -O dtb -o ${TARGET_DIR}/fixed-dtfs.dtb",
 	"layoutflash ${TARGET_DIR}/fixed-dtfs.dtb ${TARGET_DIR}/oreboot.bin",
-	"bin2vmem -o 0 <${TARGET_DIR}/rom.bin >${TARGET_DIR}/rom.vmem",
+	"bin2vmem -o 0 <${TARGET_DIR}/bootblob.bin >${TARGET_DIR}/bootblob.vmem",
 	"bin2vmem -o 0 <${TARGET_DIR}/oreboot.bin >${TARGET_DIR}/oreboot.vmem",
 	"bin2vmem -o 0 <${TARGET_DIR}/flash.bin >${TARGET_DIR}/oreboot.vmem",
 ]
@@ -42,8 +42,8 @@ args = ["xbuild", "@@split(CARGO_ARGS, )"]
 [tasks.run]
 dependencies = ["default"]
 command = "Vtop_earlgrey_verilator"
-args = ["-t", "--rominit=${TARGET_DIR}/rom.vmem",
-	"--flashinit=${TARGET_DIR}/oreboot.vmem" ]
+args = ["-t", "--rominit=rom.vmem",
+	"--flashinit=${TARGET_DIR}/bootblob.vmem" ]
 
 [tasks.objdump]
 dependencies = [ "build" ]

--- a/src/mainboard/opentitan/crb/README.md
+++ b/src/mainboard/opentitan/crb/README.md
@@ -22,7 +22,15 @@ If you do this:
 PATH=$PATH:/path/to/some/place/opentitan-snapshot-20191101-2/hw/top_earlgrey
 ```
 
-Running:
+## Running:
+
+### Emulator
+To run on the verilator modify `drivers/uart/src/opentitan.rs` 
+as specified by the note.
+
+Copy /path/to/some/place/opentitan-snapshot-20191101-2/sw/device/sim/boot_rom/rom.vmem to your
+local directory.
+
 ```
 cargo make -p release run
 ```
@@ -32,3 +40,18 @@ You will see trace output in a file named
 ```
 trace_core_00000000.log
 ```
+
+## Hardware 
+
+```
+cargo make -p release
+```
+
+Using the opentitan snapshot and running the earlgrey bitstream run:
+```
+/path/to/some/place/opentitan-snapshot-20191101-2/sw/host/spiflash/spiflash --input=target/riscv32imc-unknown-none-elf/release/bootblob.bin
+```
+
+Make sure to be connected the the device at baud rate 230400
+
+

--- a/src/mainboard/opentitan/crb/link.ld
+++ b/src/mainboard/opentitan/crb/link.ld
@@ -27,12 +27,11 @@ ENTRY(_boot);
 SECTIONS
 {
 
-    . = 0x00008000;
+    . = 0x20000000;
     .bootblock :
     {
         KEEP(*(.bootblock.boot));
     }
-    . = 0x20000000;
     .text :
     {
         KEEP(*(.text .text.*));

--- a/src/mainboard/opentitan/crb/src/main.rs
+++ b/src/mainboard/opentitan/crb/src/main.rs
@@ -13,6 +13,8 @@ use print;
 use uart::opentitan::OpenTitanUART;
 use wrappers::{Memory, SectionReader, SliceReader};
 
+const BAUDRATE: u32 = 230400;
+
 #[no_mangle]
 pub extern "C" fn _start_boot_hart(_hart_id: usize, fdt_address: usize) -> ! {
     // Set up the pinmux. This is highly board dependent.
@@ -33,7 +35,7 @@ pub extern "C" fn _start_boot_hart(_hart_id: usize, fdt_address: usize) -> ! {
     m.pwrite(&[0xd6u8, 0x85u8, 0x65u8, 0x1au8, ], 0x40070030).unwrap();
     m.pwrite(&[0x1bu8, 0xd7u8, 0x79u8, 0x1fu8, ], 0x40070034).unwrap();
     m.pwrite(&[0x60u8, 0x08u8, 0x00u8, 0x00u8, ], 0x40070038).unwrap();
-    let uart0 = &mut OpenTitanUART::new(0x40000000, 115200);
+    let uart0 = &mut OpenTitanUART::new(0x40000000, BAUDRATE);
     uart0.init();
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
 
@@ -85,7 +87,7 @@ pub extern "C" fn abort() {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     // Assume that uart0.init() has already been called before the panic.
-    let uart0 = &mut OpenTitanUART::new(0x40000000, 115200);
+    let uart0 = &mut OpenTitanUART::new(0x40000000, BAUDRATE);
     let w = &mut print::WriteTo::new(uart0);
     // Printing in the panic handler is best-effort because we really don't want to invoke the panic
     // handler from inside itself.


### PR DESCRIPTION
This fixes the baud rate to control register value calculations in
the opentitan uart driver. This also fixed the linker script to make
an earlgrey compatible binary. This will create a bootblob.bin file
that can be written to the earlgrey flash.

Signed-off-by: Ian Goegebuer <ian@iangoegebuer.com>