### PR TITLE
Clean up the x86 bootblock

### DIFF
--- a/src/arch/x86/x86_64/src/bootblock.S
+++ b/src/arch/x86/x86_64/src/bootblock.S
@@ -101,16 +101,54 @@ _start16bit:
 	 * See IA32 manual Vol 3A 19.26 Interrupts.
 	 */
 
-/*
+	// place address of the next block on the stack.
+	nop // sleazy force alignment of idt
+	call 3f
+	// null idt
+	// TBD -- align it. but it's not required. .align	4
+	.word	0	/* limit */
+	.long	0
+	.word	0
+.globl gdtptr
+gdtptr:
+	.word	gdt_end - gdt -1 /* compute the table limit */
+	.long	gdt		 /* we know the offset */
+
+	.align	4
+gdt:
+	/* selgdt 0, unused */
+	.word	0x0000, 0x0000		/* dummy */
+	.byte	0x00, 0x00, 0x00, 0x00
+
+	/* selgdt 0x08, flat code segment */
+	.word	0xffff, 0x0000
+	.byte	0x00, 0x9b, 0xcf, 0x00 /* G=1 and 0x0f, So we get 4Gbytes
+					  for limit */
+	/* selgdt 0x10,flat data segment */
+	.word	0xffff, 0x0000
+	.byte	0x00, 0x93, 0xcf, 0x00
+
+	/* selgdt 0x18, flat code segment (64-bit) */
+	.word   0xffff, 0x0000
+	.byte   0x00, 0x9b, 0xaf, 0x00
+
+gdt_end:
+.globl gdtptr16
+gdtptr16:
+	.word	gdt_end - gdt -1 /* compute the table limit */
+	.long	gdt		 /* we know the offset */
+3:
+	popw	%cx
+	movw	%cx, %bx
 	movw	%cs, %ax
 	shlw	$4, %ax
-	movw	$nullidt_offset, %bx
 	subw	%ax, %bx
 	lidt	%cs:(%bx)
-	movw	$gdtptr16_offset, %bx
+	// The gdb is at the idt plus 8
+	movw	%cx, %bx
+	addw    $8, %bx
 	subw	%ax, %bx
 	lgdtl	%cs:(%bx)
-*/
 
 	movl	%cr0, %eax
 	andl	$0x7FFAFFD1, %eax /* PG,AM,WP,NE,TS,EM,MP = 0 */
@@ -136,43 +174,6 @@ gdt_init:
 
 .previous
 	.align	4
-.globl gdtptr
-gdtptr:
-	.word	gdt_end - gdt -1 /* compute the table limit */
-	.long	gdt		 /* we know the offset */
-
-	.align	4
-gdt:
-	/* selgdt 0, unused */
-	.word	0x0000, 0x0000		/* dummy */
-	.byte	0x00, 0x00, 0x00, 0x00
-
-	/* selgdt 0x08, flat code segment */
-	.word	0xffff, 0x0000
-	.byte	0x00, 0x9b, 0xcf, 0x00 /* G=1 and 0x0f, So we get 4Gbytes
-					  for limit */
-
-	/* selgdt 0x10,flat data segment */
-	.word	0xffff, 0x0000
-	.byte	0x00, 0x93, 0xcf, 0x00
-
-	/* selgdt 0x18, flat code segment (64-bit) */
-	.word   0xffff, 0x0000
-	.byte   0x00, 0x9b, 0xaf, 0x00
-
-gdt_end:
-.globl gdtptr16
-gdtptr16:
-	.word	gdt_end - gdt -1 /* compute the table limit */
-	.long	gdt		 /* we know the offset */
-
-.align	4
-.globl nullidt
-nullidt:
-	.word	0	/* limit */
-	.long	0
-	.word	0
-
 .globl _estart16bit
 _estart16bit:
 	.code32
@@ -224,6 +225,7 @@ __protected_start:
 #include <cpu/x86/64bit/entry64.inc>
 	mov	%ebx, %eax
 
+1: jmp 1b
 	// This is code which lives at 0xfffffff0.
 	.section ".reset", "ax", %progbits
 //	.code16

--- a/src/mainboard/emulation/qemu-q35/Makefile.toml
+++ b/src/mainboard/emulation/qemu-q35/Makefile.toml
@@ -14,7 +14,9 @@ TARGET_DIR = "target/x86_64-unknown-none/release"
 install_crate = { rustup_component_name = "rust-src" }
 
 [tasks.default]
-dependencies = [ "bootblob" ]
+dependencies = [ "resizeblob" ]
+command = "qemu-img"
+args = ["resize", "${TARGET_DIR}/bootblob.bin", "65536"]
 
 [tasks.build]
 dependencies = [ "install-rust-src" ]
@@ -29,13 +31,11 @@ args = ["objcopy", "--", "-O", "binary", "${TARGET_DIR}/oreboot", "${TARGET_DIR}
 
 [tasks.resizeblob]
 dependencies = [ "bootblob" ]
-command = "qemu-img"
-args = ["resize", "${TARGET_DIR}/bootblob.bin", "33554432"]
 
 [tasks.run]
 dependencies = ["resizeblob"]
 command = "qemu-system-x86_64"
-args = ["-m", "1g", "-machine", "q35", "-nographic", "-bios", "none", "-pflash", "${TARGET_DIR}/bootblob.bin"]
+args = ["-m", "1g", "-machine", "q35", "-nographic", "-bios", "${TARGET_DIR}/bootblob.bin"]
 
 [tasks.objdump]
 dependencies = ["build"]

--- a/src/mainboard/emulation/qemu-q35/link.ld
+++ b/src/mainboard/emulation/qemu-q35/link.ld
@@ -32,6 +32,8 @@ SECTIONS
         KEEP(*(.bootblock.boot));
         KEEP(*(.text .text.*));
         KEEP(*(.rodata .rodata.*));
+	/* There should be no 'data' as such but we'll fix it later */
+        KEEP(*(.data.*))
     }
 
     . = 0xfffffff0;


### PR DESCRIPTION
This now gets through the lidt and lgdt, and the little call trick
avoids linker messes.

You can do this:
qemu-system-x86_64 -bios target/x86_64-unknown-none/release/bootblob.bin -monitor stdio
QEMU 3.1.50 monitor - type 'help' for more information
(qemu) VNC server running on ::1:5900
x/i $pc
0xffff00a1:  eb fe                    jmp      0xffff00a1
(qemu) quit

Next: 64-bit mode.