### PR TITLE
uart/null: Replace Null with unit-like type

### DIFF
--- a/src/drivers/uart/src/null.rs
+++ b/src/drivers/uart/src/null.rs
@@ -1,25 +1,15 @@
 // null is a simple Null driver.
 // TODO: move it out of uart.
-use core::ops;
 use model::*;
 
-pub struct Null {
- 
-}
-
-impl Null {
-    pub fn new() -> Null {
-        Null { }
-    }
-
-}
+pub struct Null;
 
 impl Driver for Null {
     fn init(&mut self) -> Result<()> {
         Ok(())
     }
 
-    fn pread(&self, data: &mut [u8], _offset: usize) -> Result<usize> {
+    fn pread(&self, _data: &mut [u8], _offset: usize) -> Result<usize> {
         Ok(0)
     }
 

--- a/src/mainboard/emulation/qemu-q35/src/main.rs
+++ b/src/mainboard/emulation/qemu-q35/src/main.rs
@@ -17,7 +17,7 @@ global_asm!(include_str!("../../../../arch/x86/x86_64/src/bootblock.S"));
 
 #[no_mangle]
 pub extern "C" fn _start(fdt_address: usize) -> ! {
-    let uart0 = &mut Null::new();
+    let uart0 = &mut Null;
     uart0.init().unwrap();
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
 
@@ -56,7 +56,7 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     // Assume that uart0.init() has already been called before the panic.
-    let uart0 = &mut Null::new();
+    let uart0 = &mut Null;
     let w = &mut print::WriteTo::new(uart0);
     // Printing in the panic handler is best-effort because we really don't want to invoke the panic
     // handler from inside itself.


### PR DESCRIPTION
Also clean up warnings, and drop Null::new() given that unit-like types
introduce a type-named constant of the same type.

Signed-off-by: Garret Kelly <gdk@google.com>