### PR TITLE
Fix warnings for the qemu-riscv mainboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ cargo make -p release   # Optimized
 # View disassembly
 cargo make objdump -p release
 
+# Run in QEMU simulation
+cargo make run -p release
+
 # Alternatively, without setting OREBOOT, you can do like this
 cargo make --env OREBOOT="${PWD}" --cwd src/mainboard/sifive/hifive
 ```

--- a/src/mainboard/emulation/qemu-riscv/Makefile.toml
+++ b/src/mainboard/emulation/qemu-riscv/Makefile.toml
@@ -30,12 +30,12 @@ args = ["objcopy", "--", "-O", "binary", "${TARGET_DIR}/oreboot", "${TARGET_DIR}
 [tasks.resizeblob]
 dependencies = [ "bootblob" ]
 command = "qemu-img"
-args = ["resize", "${TARGET_DIR}/bootblob.bin", "33554432"]
+args = ["resize", "-f", "raw", "${TARGET_DIR}/bootblob.bin", "33554432"]
 
 [tasks.run]
 dependencies = ["resizeblob"]
 command = "qemu-system-riscv64"
-args = ["-m", "1g", "-machine", "virt", "-nographic", "-bios", "none", "-pflash", "${TARGET_DIR}/bootblob.bin"]
+args = ["-m", "1g", "-machine", "virt", "-nographic", "-bios", "none", "-drive", "format=raw,if=pflash,file=${TARGET_DIR}/bootblob.bin"]
 
 [tasks.objdump]
 dependencies = ["build"]

--- a/src/mainboard/emulation/qemu-riscv/src/main.rs
+++ b/src/mainboard/emulation/qemu-riscv/src/main.rs
@@ -18,7 +18,7 @@ global_asm!(include_str!("init.S"));
 #[no_mangle]
 pub extern "C" fn _start(fdt_address: usize) -> ! {
     let uart0 = &mut NS16550::new(0x10000000, 115200);
-    uart0.init();
+    uart0.init().unwrap();
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
 
     let w = &mut print::WriteTo::new(uart0);


### PR DESCRIPTION
Unwraps the result of the uart init and specifes the "raw" format when QEMU is resizing and running.