### PR TITLE
Implement SiFive SPI Driver

### DIFF
--- a/Documentation/sifive/setup.md
+++ b/Documentation/sifive/setup.md
@@ -23,6 +23,8 @@ cargo make -p release
 # The output is target/riscv64imac-unknown-none-elf/release/oreboot.bin
 ```
 
+## Flashing with flashrom
+
 4. While flashing, make sure all external power is removed from the board.
    Using a 16-pin Pomona clip, connect a SF100 to the board as seen in the
    image below.
@@ -55,6 +57,13 @@ minicom -D /dev/ttyUSB1 -b 115200
 
 ![USB](usb.jpg)
 
+## Alternate: Flashing with OpenOCD
+
+4. With RISC-V OpenOCD installed on your system, the HiFive unleashed can be programmed over USB:
+
+```
+cargo make -p release flash-openocd
+```
 
 ## Debugging with GDB
 

--- a/src/drivers/sifive/spi/src/lib.rs
+++ b/src/drivers/sifive/spi/src/lib.rs
@@ -1,6 +1,24 @@
+/*
+ * This file is part of the oreboot project.
+ *
+ * Copyright (C) 2020 SiFive Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/*
+ * This is a driver for the SiFive SPI Controller, documented in the FU540 manual:
+ * https://www.sifive.com/documentation/chips/freedom-u540-c000-manual/
+ */
 #![no_std]
 #![deny(warnings)]
-/// This is a driver for SiFive's SPI master, documented in the FU540 manual:
 
 use model::*;
 use core::ops;

--- a/src/drivers/sifive/spi/src/lib.rs
+++ b/src/drivers/sifive/spi/src/lib.rs
@@ -9,54 +9,97 @@ use clock::ClockNode;
 use register::mmio::{ReadOnly, ReadWrite};
 use register::{register_bitfields};
 
+const RETRY_COUNT: u32 = 100_000;
+
+pub enum SiFiveSpiPhase {
+    SampleLeading,
+    SampleTrailing
+}
+
+pub enum SiFiveSpiPolarity {
+    InactiveLow,
+    InactiveHigh
+}
+
+pub enum SiFiveSpiProtocol {
+    Single,
+    Dual,
+    Quad
+}
+
+pub enum SiFiveSpiEndianness {
+    BigEndian,
+    LittleEndian
+}
+
+pub struct SiFiveSpiConfig {
+    pub freq: u32,
+    pub phase: SiFiveSpiPhase,
+    pub polarity: SiFiveSpiPolarity,
+    pub protocol: SiFiveSpiProtocol,
+    pub endianness: SiFiveSpiEndianness,
+    pub bits_per_frame: u8
+}
+
+pub struct SiFiveSpiMmapConfig {
+    pub command_enable: bool,
+    pub address_len: u8,
+    pub pad_count: u8,
+    pub command_protocol: SiFiveSpiProtocol,
+    pub address_protocol: SiFiveSpiProtocol,
+    pub data_protocol: SiFiveSpiProtocol,
+    pub command_code: u8,
+    pub pad_code: u8
+}
+
 #[repr(C)]
 pub struct RegisterBlock {
     /// Serial clock divisor
-    sckdiv: ReadWrite<u32, SCKDIV::Register>,
+    sckdiv: ReadWrite<u32, ClockDivider::Register>,
     /// Serial clock mode
-    sckmode: ReadWrite<u32>,
+    sckmode: ReadWrite<u32, ClockMode::Register>,
     _reserved0: u32,
     _reserved1: u32,
     /// Chip select ID
-    csid: ReadWrite<u32>,
+    csid: ReadWrite<u32, ActiveChipSelect::Register>,
     /// Chip select default
-    csdef: ReadWrite<u32>,
+    csdef: ReadWrite<u32, ChipSelectDefault::Register>,
     /// Chip select mode
-    csmode: ReadWrite<u32>,
+    csmode: ReadWrite<u32, ChipSelectMode::Register>,
     _reserved2: u32,
     _reserved3: u32,
     _reserved4: u32,
     /// Delay control 0
-    delay0: ReadWrite<u32>,
+    delay0: ReadWrite<u32, DelayControl0::Register>,
     /// Delay control 1
-    delay1: ReadWrite<u32>,
+    delay1: ReadWrite<u32, DelayControl1::Register>,
     _reserved5: u32,
     _reserved6: u32,
     _reserved7: u32,
     _reserved8: u32,
     /// Frame format
-    fmt: ReadWrite<u32>,
+    fmt: ReadWrite<u32, Format::Register>,
     _reserved9: u32,
     /// Tx FIFO Data
-    txdata: ReadWrite<u32>,
+    txdata: ReadWrite<u32, TransmitData::Register>,
     /// Rx FIFO data
-    rxdata: ReadWrite<u32>,
+    rxdata: ReadOnly<u32, ReceiveData::Register>,
     /// Tx FIFO watermark
-    txmark: ReadWrite<u32>,
+    txmark: ReadWrite<u32, TransmitMark::Register>,
     /// Rx FIFO watermark
-    rxmark: ReadWrite<u32>,
+    rxmark: ReadWrite<u32, ReceiveMark::Register>,
     _reserved10: u32,
     _reserved11: u32,
     /// SPI flash interface control
-    fctrl: ReadWrite<u32>,
+    fctrl: ReadWrite<u32, FlashControl::Register>,
     /// SPI flash instruction format
-    ffmt: ReadWrite<u32>,
+    ffmt: ReadWrite<u32, FlashFormat::Register>,
     _reserved12: u32,
     _reserved13: u32,
     /// SPI interrupt enable
-    ie: ReadWrite<u32>,
+    ie: ReadWrite<u32, InterruptEnable::Register>,
     /// SPI interrupt pending
-    ip: ReadOnly<u32>,
+    ip: ReadOnly<u32, InterruptPending::Register>,
 }
 
 pub struct SiFiveSpi {
@@ -73,8 +116,133 @@ impl ops::Deref for SiFiveSpi {
 
 register_bitfields! {
     u32,
-    SCKDIV [
+    ClockDivider [
         DIV OFFSET(0) NUMBITS(12) []
+    ],
+    ClockMode [
+        PHA OFFSET(0) NUMBITS(1) [
+            SampleLeading  = 0,
+            SampleTrailing = 1
+        ],
+        POL OFFSET(1) NUMBITS(1) [
+            InactiveLow  = 0,
+            InactiveHigh = 1
+        ]
+    ],
+    ActiveChipSelect [
+        ID OFFSET(0) NUMBITS(32) []
+    ],
+    ChipSelectDefault [
+        DEF0 OFFSET(0) NUMBITS(1) [],
+        DEF1 OFFSET(0) NUMBITS(1) [],
+        DEF2 OFFSET(0) NUMBITS(1) [],
+        DEF3 OFFSET(0) NUMBITS(1) [],
+        DEF4 OFFSET(0) NUMBITS(1) [],
+        DEF5 OFFSET(0) NUMBITS(1) [],
+        DEF6 OFFSET(0) NUMBITS(1) [],
+        DEF7 OFFSET(0) NUMBITS(1) [],
+        DEF8 OFFSET(0) NUMBITS(1) [],
+        DEF9 OFFSET(0) NUMBITS(1) [],
+        DEF10 OFFSET(0) NUMBITS(1) [],
+        DEF11 OFFSET(0) NUMBITS(1) [],
+        DEF12 OFFSET(0) NUMBITS(1) [],
+        DEF13 OFFSET(0) NUMBITS(1) [],
+        DEF14 OFFSET(0) NUMBITS(1) [],
+        DEF15 OFFSET(0) NUMBITS(1) [],
+        DEF16 OFFSET(0) NUMBITS(1) [],
+        DEF17 OFFSET(0) NUMBITS(1) [],
+        DEF18 OFFSET(0) NUMBITS(1) [],
+        DEF19 OFFSET(0) NUMBITS(1) [],
+        DEF20 OFFSET(0) NUMBITS(1) [],
+        DEF21 OFFSET(0) NUMBITS(1) [],
+        DEF22 OFFSET(0) NUMBITS(1) [],
+        DEF23 OFFSET(0) NUMBITS(1) [],
+        DEF24 OFFSET(0) NUMBITS(1) [],
+        DEF25 OFFSET(0) NUMBITS(1) [],
+        DEF26 OFFSET(0) NUMBITS(1) [],
+        DEF27 OFFSET(0) NUMBITS(1) [],
+        DEF28 OFFSET(0) NUMBITS(1) [],
+        DEF29 OFFSET(0) NUMBITS(1) [],
+        DEF30 OFFSET(0) NUMBITS(1) [],
+        DEF31 OFFSET(0) NUMBITS(1) []
+    ],
+    ChipSelectMode [
+        MODE OFFSET(0) NUMBITS(2) [
+            Auto = 0b00,
+            Hold = 0b10,
+            Off  = 0b11
+        ]
+    ],
+    DelayControl0 [
+        CSSCK OFFSET(0) NUMBITS(8) [],
+        SCKCS OFFSET(16) NUMBITS(8) []
+    ],
+    DelayControl1 [
+        InterCS OFFSET(0) NUMBITS(8) [],
+        InterXfr OFFSET(16) NUMBITS(8) []
+    ],
+    Format [
+        Protocol OFFSET(0) NUMBITS(2) [
+            Single = 0b00,
+            Dual   = 0b01,
+            Quad   = 0b10
+        ],
+        Endianness OFFSET(2) NUMBITS(1) [
+            MSB = 0b0,
+            LSB = 0b1
+        ],
+        Direction OFFSET(3) NUMBITS(1) [
+            Rx = 0b0,
+            Tx = 0b1
+        ],
+        Length OFFSET(16) NUMBITS(4) []
+    ],
+    TransmitData [
+        Data OFFSET(0) NUMBITS(8) [],
+        Full OFFSET(31) NUMBITS(1) []
+    ],
+    ReceiveData [
+        Data OFFSET(0) NUMBITS(8) [],
+        Empty OFFSET(31) NUMBITS(1) []
+    ],
+    TransmitMark [
+        TXWM OFFSET(0) NUMBITS(3) []
+    ],
+    ReceiveMark [
+        RXWM OFFSET(0) NUMBITS(3) []
+    ],
+    InterruptEnable [
+        TXWMIE OFFSET(0) NUMBITS(1) [],
+        RXWMIE OFFSET(1) NUMBITS(1) []
+    ],
+    InterruptPending [
+        TXWMIP OFFSET(0) NUMBITS(1) [],
+        RXWMIP OFFSET(1) NUMBITS(1) []
+    ],
+    FlashControl [
+        MMAPEN OFFSET(0) NUMBITS(1) []
+    ],
+    FlashFormat [
+        CMD_EN OFFSET(0) NUMBITS(1) [],
+        ADDR_LEN OFFSET(1) NUMBITS(3) [],
+        PAD_CNT OFFSET(4) NUMBITS(4) [],
+        CMD_PROTO OFFSET(8) NUMBITS(2) [
+            Single = 0b00,
+            Dual   = 0b01,
+            Quad   = 0b10
+        ],
+        ADDR_PROTO OFFSET(10) NUMBITS(2) [
+            Single = 0b00,
+            Dual   = 0b01,
+            Quad   = 0b10
+        ],
+        DATA_PROTO OFFSET(12) NUMBITS(2) [
+            Single = 0b00,
+            Dual   = 0b01,
+            Quad   = 0b10
+        ],
+        CMD_CODE OFFSET(16) NUMBITS(8) [],
+        PAD_CODE OFFSET(24) NUMBITS(8) []
     ]
 }
 
@@ -87,23 +255,103 @@ impl SiFiveSpi {
     fn ptr(&self) -> *const RegisterBlock {
         self.base as *const _
     }
+
+    pub fn setup(&mut self, cs: u32, config: SiFiveSpiConfig) -> Result<()> {
+        self.set_clock_rate(config.freq);
+        self.csid.write(ActiveChipSelect::ID.val(cs));
+        match config.phase {
+            SiFiveSpiPhase::SampleLeading  => self.sckmode.modify(ClockMode::PHA::SampleLeading),
+            SiFiveSpiPhase::SampleTrailing => self.sckmode.modify(ClockMode::PHA::SampleTrailing),
+        }
+        match config.polarity {
+            SiFiveSpiPolarity::InactiveLow  => self.sckmode.modify(ClockMode::POL::InactiveLow),
+            SiFiveSpiPolarity::InactiveHigh => self.sckmode.modify(ClockMode::POL::InactiveHigh),
+        }
+        match config.protocol {
+            SiFiveSpiProtocol::Single => self.fmt.modify(Format::Protocol::Single),
+            SiFiveSpiProtocol::Dual   => self.fmt.modify(Format::Protocol::Dual),
+            SiFiveSpiProtocol::Quad   => self.fmt.modify(Format::Protocol::Quad),
+        }
+        match config.endianness {
+            SiFiveSpiEndianness::LittleEndian => self.fmt.modify(Format::Endianness::LSB),
+            SiFiveSpiEndianness::BigEndian => self.fmt.modify(Format::Endianness::MSB),
+        }
+        self.fmt.modify(Format::Direction::Tx);
+        self.fmt.modify(Format::Length.val(config.bits_per_frame.into()));
+
+        Ok(())
+    }
+
+    pub fn mmap(&mut self, config: SiFiveSpiMmapConfig) -> Result<()> {
+        // Disable memory mapped mode before configuring
+        self.fctrl.modify(FlashControl::MMAPEN.val(0));
+
+        // Reset SPI Flash chip
+        self.pwrite(&[0x66, 0x99], 0).unwrap();
+
+        self.ffmt.modify(FlashFormat::CMD_EN.val(config.command_enable.into()));
+        self.ffmt.modify(FlashFormat::ADDR_LEN.val(config.address_len.into()));
+        self.ffmt.modify(FlashFormat::PAD_CNT.val(config.pad_count.into()));
+        match config.command_protocol {
+            SiFiveSpiProtocol::Single => self.ffmt.modify(FlashFormat::CMD_PROTO::Single),
+            SiFiveSpiProtocol::Dual   => self.ffmt.modify(FlashFormat::CMD_PROTO::Dual),
+            SiFiveSpiProtocol::Quad   => self.ffmt.modify(FlashFormat::CMD_PROTO::Quad),
+        }
+        match config.address_protocol {
+            SiFiveSpiProtocol::Single => self.ffmt.modify(FlashFormat::ADDR_PROTO::Single),
+            SiFiveSpiProtocol::Dual   => self.ffmt.modify(FlashFormat::ADDR_PROTO::Dual),
+            SiFiveSpiProtocol::Quad   => self.ffmt.modify(FlashFormat::ADDR_PROTO::Quad),
+        }
+        match config.data_protocol {
+            SiFiveSpiProtocol::Single => self.ffmt.modify(FlashFormat::DATA_PROTO::Single),
+            SiFiveSpiProtocol::Dual   => self.ffmt.modify(FlashFormat::DATA_PROTO::Dual),
+            SiFiveSpiProtocol::Quad   => self.ffmt.modify(FlashFormat::DATA_PROTO::Quad),
+        }
+        self.ffmt.modify(FlashFormat::CMD_CODE.val(config.command_code.into()));
+        self.ffmt.modify(FlashFormat::PAD_CODE.val(config.pad_code.into()));
+
+        // Re-enable memory mapped mode
+        self.fctrl.modify(FlashControl::MMAPEN.val(1));
+
+        Ok(())
+    }
 }
 
 impl Driver for SiFiveSpi {
     fn init(&mut self) -> Result<()> {
-        // TODO: Implement init
+        // Disable Interrupts
+        self.ie.set(0 as u32);
+        // Set rate to 33.33 MHz
         self.set_clock_rate(33_330_000);
+
         Ok(())
     }
 
-    fn pread(&self, _data: &mut [u8], _offset: usize) -> Result<usize> {
-        // TODO: Implement pread
-        NOT_IMPLEMENTED
+    fn pread(&self, data: &mut [u8], _offset: usize) -> Result<usize> {
+        'outer: for (read_count, c) in data.iter_mut().enumerate() {
+            for _ in 0..RETRY_COUNT {
+                let rxdata_copy = self.rxdata.extract();
+                if ! rxdata_copy.is_set(ReceiveData::Empty) {
+                    *c = rxdata_copy.read(ReceiveData::Data) as u8;
+                    continue 'outer;
+                }
+            }
+            return Ok(read_count);
+        }
+        Ok(data.len())
     }
 
-    fn pwrite(&mut self, _data: &[u8], _offset: usize) -> Result<usize> {
-        // TODO: Implement wread
-        NOT_IMPLEMENTED
+    fn pwrite(&mut self, data: &[u8], _offset: usize) -> Result<usize> {
+        'outer: for (sent_count, &c) in data.iter().enumerate() {
+            for _ in 0..RETRY_COUNT {
+                if ! self.txdata.is_set(TransmitData::Full) {
+                    self.txdata.set(c.into());
+                    continue 'outer;
+                }
+            }
+            return Ok(sent_count);
+        }
+        Ok(data.len())
     }
 
     fn shutdown(&mut self) {}
@@ -116,6 +364,6 @@ impl ClockNode for SiFiveSpi {
         // faster than the SPI slave's specification. For this reason, the divisor rounds up.
         let denominator = 4 * self.serial_rate;
         let div = (rate + denominator - 1) / denominator;
-        self.sckdiv.modify(SCKDIV::DIV.val(div));
+        self.sckdiv.modify(ClockDivider::DIV.val(div));
     }
 }

--- a/src/mainboard/sifive/hifive/Cargo.lock
+++ b/src/mainboard/sifive/hifive/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "clock 0.1.0",
  "model 0.1.0",
  "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spi 0.1.0",
 ]
 
 [[package]]

--- a/src/mainboard/sifive/hifive/Makefile.toml
+++ b/src/mainboard/sifive/hifive/Makefile.toml
@@ -49,6 +49,10 @@ dependencies = ["default"]
 command = "qemu-system-riscv64"
 args = ["-m", "1g", "-machine", "sifive_u,start-in-flash=true", "-nographic", "-device", "loader,addr=0x20000000,file=${TARGET_DIR}/oreboot.bin", "-bios", "none", "-d", "guest_errors", "-s", "-S", "-smp", "4"]
 
+[tasks.flash-openocd]
+dependencies = ["default"]
+script = ["$(which openocd) -f openocd.cfg -c \"flash write_image erase unlock ${TARGET_DIR}/oreboot.bin 0x20000000; shutdown\"",]
+
 [tasks.objdump]
 dependencies = ["build"]
 command = "cargo"

--- a/src/mainboard/sifive/hifive/openocd.cfg
+++ b/src/mainboard/sifive/hifive/openocd.cfg
@@ -1,0 +1,19 @@
+adapter_khz     10000
+
+interface ftdi
+ftdi_device_desc "Dual RS232-HS"
+ftdi_vid_pid 0x0403 0x6010
+
+ftdi_layout_init 0x0008 0x001b
+ftdi_layout_signal nSRST -oe 0x0020 -data 0x0020
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
+$_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
+
+flash bank onboard_spi_flash fespi 0x20000000 0 0 0 $_TARGETNAME 0x10040000
+init
+halt

--- a/src/mainboard/sifive/hifive/src/main.rs
+++ b/src/mainboard/sifive/hifive/src/main.rs
@@ -74,6 +74,14 @@ pub extern "C" fn _start_boot_hart(_hart_id: usize, fdt_address: usize) -> ! {
     clk.pwrite(b"on", 0).unwrap();
     uart0.pwrite(b"Done\r\n", 0).unwrap();
 
+    if !is_qemu() {
+        uart0.pwrite(b"Initializing SPI controller...", 0).unwrap();
+        spi0.init().unwrap();
+        spi0.setup(0, soc::spi::FU540SPICONFIG).unwrap();
+        spi0.mmap(soc::spi::FU540SPIMMAPCONFIG).unwrap();
+        uart0.pwrite(b"Done\r\n", 0).unwrap();
+    }
+
     let w = &mut print::WriteTo::new(uart0);
 
     write!(w, "## ROM Device Tree\r\n").unwrap();

--- a/src/soc/sifive/fu540/Cargo.toml
+++ b/src/soc/sifive/fu540/Cargo.toml
@@ -11,5 +11,6 @@ opt-level = 'z'  # Optimize for size.
 arch = { path = "../../../arch/riscv/rv64"}
 model = { path = "../../../drivers/model"}
 clock = { path = "../../../drivers/clock" }
+spi = { path = "../../../drivers/sifive/spi" }
 register = "0.3.2"
 

--- a/src/soc/sifive/fu540/src/lib.rs
+++ b/src/soc/sifive/fu540/src/lib.rs
@@ -7,6 +7,7 @@ pub mod ddr;
 pub mod ddrregs;
 pub mod phy;
 pub mod reg;
+pub mod spi;
 pub mod ux00;
 
 use core::ptr;

--- a/src/soc/sifive/fu540/src/spi.rs
+++ b/src/soc/sifive/fu540/src/spi.rs
@@ -1,0 +1,21 @@
+use spi::*;
+
+pub const FU540_SPI_CONFIG: SiFiveSpiConfig = SiFiveSpiConfig {
+    freq: 33_330_000,
+    phase: SiFiveSpiPhase::SampleLeading,
+    polarity: SiFiveSpiPolarity::InactiveLow,
+    protocol: SiFiveSpiProtocol::Single,
+    endianness: SiFiveSpiEndianness::BigEndian,
+    bits_per_frame: 8
+};
+
+pub const FU540_SPI_MMAP_CONFIG: SiFiveSpiMmapConfig = SiFiveSpiMmapConfig {
+    command_enable: true,
+    address_len: 4,
+    pad_count: 6,
+    command_protocol: SiFiveSpiProtocol::Single,
+    address_protocol: SiFiveSpiProtocol::Quad,
+    data_protocol: SiFiveSpiProtocol::Quad,
+    command_code: 0xec,
+    pad_code: 0
+};


### PR DESCRIPTION
In response to #152, implements enough of the SPI driver to enable the full 256 MB memory space mapped by the SPI controller on the FU540. I tried to copy the `fu540_spi_setup()` and `fu540_spi_mmap()` APIs created in Coreboot to do this configuration.

This doesn't yet allow us to configure SPI0 to use its full memory space, though, because right now Oreboot executes exclusively out of the SPI0 memory space. Without an SD card boot flow or the ability to jump to a second boot stage not executing out of the boot flash, this is the most I can do right now.

I'm also including a patch to include an OpenOCD config file and a cargo-make target to program the Unleashed with OpenOCD. It's the most convenient programming method available to me, but if we don't want it in the project I can remove the commit from this PR.

The driver code was missing a copyright and license, so I added one. Clearly since I'm extending the file the copyright belongs to more than just SiFive, should I add others based on `git blame`?