### PR TITLE
Fix build with latest nightly rustc and cargo objcopy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ firsttime:
 	curl https://sh.rustup.rs -sSf | sh
 	rustup override set nightly
 	rustup component add rust-src llvm-tools-preview
+	rustup target add riscv64imac-unknown-none-elf
+	rustup target add riscv32imc-unknown-none-elf
+	rustup target add armv7r-none-eabi
 	cargo install cargo-xbuild cargo-binutils
 	sudo apt-get install device-tree-compiler pkg-config libssl-dev
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(MAINBOARDS):
 	cd src/mainboard/$@ && make
 
 firsttime:
-	curl https://sh.rustup.rs -sSf | sh
+	curl https://sh.rustup.rs -sSf | sh -s -- -y
 	rustup override set nightly
 	rustup component add rust-src llvm-tools-preview
 	rustup target add riscv64imac-unknown-none-elf

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -42,7 +42,7 @@ $(IMAGE): $(BOOTBLOB) $(FIXED_DTFS)
 	@printf "**\n** Output: $@\n**\n"
 
 $(TARGET_DIR)/bootblob.bin: $(ELF)
-	RUST_TARGET_PATH=$(TOP)/src/custom_targets cargo objcopy -- -O binary -R .bss $< $@
+	RUST_TARGET_PATH=$(TOP)/src/custom_targets cargo objcopy --bin $(notdir $<) -- -O binary -R .bss $@
 
 # Re-run cargo every time.
 .PHONY: $(ELF)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,7 @@ pool:
 
 steps:
 - script: |
-    curl https://sh.rustup.rs -sSf | sh
-    rustup override set nightly
-    rustup component add rust-src llvm-tools-preview
-    cargo install cargo-xbuild cargo-binutils
-    sudo apt-get install device-tree-compiler
+    make firsttime
   displayName: 'Install Rust Dependencies'
 - script: |
     cd src/mainboard/sifive/hifive

--- a/src/arch/riscv/rv32/src/lib.rs
+++ b/src/arch/riscv/rv32/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![feature(global_asm)]
@@ -11,14 +11,14 @@ pub fn halt() -> ! {
     loop {
         // Bug with LLVM marks empty loops as undefined behaviour.
         // See: https://github.com/rust-lang/rust/issues/28728
-        unsafe { asm!("wfi" :::: "volatile") }
+        unsafe { llvm_asm!("wfi" :::: "volatile") }
     }
 }
 
 pub fn fence() {
-    unsafe { asm!("fence" :::: "volatile") }
+    unsafe { llvm_asm!("fence" :::: "volatile") }
 }
 
 pub fn nop() {
-    unsafe { asm!("nop" :::: "volatile") }
+    unsafe { llvm_asm!("nop" :::: "volatile") }
 }

--- a/src/arch/riscv/rv64/src/lib.rs
+++ b/src/arch/riscv/rv64/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![feature(global_asm)]
@@ -8,15 +8,15 @@ pub fn halt() -> ! {
     loop {
         // Bug with LLVM marks empty loops as undefined behaviour.
         // See: https://github.com/rust-lang/rust/issues/28728
-        unsafe { asm!("wfi" :::: "volatile") }
+        unsafe { llvm_asm!("wfi" :::: "volatile") }
     }
 }
 
 pub fn fence() {
-    unsafe { asm!("fence" :::: "volatile") }
+    unsafe { llvm_asm!("fence" :::: "volatile") }
 }
 
 pub fn nop() {
-    unsafe { asm!("nop" :::: "volatile") }
+    unsafe { llvm_asm!("nop" :::: "volatile") }
 }
 

--- a/src/arch/x86/x86_64/src/lib.rs
+++ b/src/arch/x86/x86_64/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![feature(global_asm)]
@@ -8,14 +8,14 @@ pub fn halt() -> ! {
     loop {
         // Bug with LLVM marks empty loops as undefined behaviour.
         // See: https://github.com/rust-lang/rust/issues/28728
-        unsafe { asm!("hlt" :::: "volatile") }
+        unsafe { llvm_asm!("hlt" :::: "volatile") }
     }
 }
 
 pub fn fence() {
-    unsafe { asm!("nop" :::: "volatile") }
+    unsafe { llvm_asm!("nop" :::: "volatile") }
 }
 
 pub fn nop() {
-    unsafe { asm!("nop" :::: "volatile") }
+    unsafe { llvm_asm!("nop" :::: "volatile") }
 }

--- a/src/drivers/uart/src/lib.rs
+++ b/src/drivers/uart/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(feature = "log")]
 pub mod log;

--- a/src/drivers/uart/src/opentitan.rs
+++ b/src/drivers/uart/src/opentitan.rs
@@ -251,7 +251,7 @@ impl Driver for OpenTitanUART {
             while self.status.is_set(STATUS::TXFULL) {
                 // TODO: This is an extra safety precaution to prevent LLVM from possibly removing
                 //       this loop. Remove if we deem it not necessary.
-                unsafe { asm!("" :::: "volatile") }
+                unsafe { llvm_asm!("" :::: "volatile") }
             }
             //return Ok(i);
             //}

--- a/src/mainboard/ast/ast25x0/src/main.rs
+++ b/src/mainboard/ast/ast25x0/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![no_main]
@@ -60,7 +60,7 @@ pub fn halt() -> ! {
     loop {
         // Bug with LLVM marks empty loops as undefined behaviour.
         // See: https://github.com/rust-lang/rust/issues/28728
-        unsafe { asm!("" :::: "volatile") }
+        unsafe { llvm_asm!("" :::: "volatile") }
     }
 }
 

--- a/src/mainboard/emulation/qemu-armv7/src/main.rs
+++ b/src/mainboard/emulation/qemu-armv7/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![no_main]
@@ -69,7 +69,7 @@ pub fn halt() -> ! {
     loop {
         // Bug with LLVM marks empty loops as undefined behaviour.
         // See: https://github.com/rust-lang/rust/issues/28728
-        unsafe { asm!("" :::: "volatile") }
+        unsafe { llvm_asm!("" :::: "volatile") }
     }
 }
 

--- a/src/mainboard/emulation/qemu-q35/src/main.rs
+++ b/src/mainboard/emulation/qemu-q35/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![no_main]

--- a/src/mainboard/emulation/qemu-riscv/src/main.rs
+++ b/src/mainboard/emulation/qemu-riscv/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![no_main]

--- a/src/mainboard/nuvoton/npcm7xx/src/main.rs
+++ b/src/mainboard/nuvoton/npcm7xx/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![no_main]

--- a/src/mainboard/opentitan/crb/src/main.rs
+++ b/src/mainboard/opentitan/crb/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![no_main]

--- a/src/mainboard/sifive/hifive/src/main.rs
+++ b/src/mainboard/sifive/hifive/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(lang_items, start)]
 #![no_std]
 #![no_main]
@@ -90,7 +90,7 @@ pub extern "C" fn _start_boot_hart(_hart_id: usize, fdt_address: usize) -> ! {
             let mut _val: u32 = *(0x30000000 as *const u32);
             // Volatile `and` operation of the value with itself to try and make
             // sure that we don't optimize the read out.
-            asm!("and $0, $1, $1" : "=r"(_val) : "r"(_val) :: "volatile");
+            llvm_asm!("and $0, $1, $1" : "=r"(_val) : "r"(_val) :: "volatile");
         }
         uart0.pwrite(b"Done\r\n", 0).unwrap();
     }


### PR DESCRIPTION
The current invocation seems no longer supported in cargo-binutils
0.2.0. The change herein appears to be forwards (tested 0.2.0) and
backwards (tested on 0.1.6) compatible.