### PR TITLE
Use rust-objcopy instead of cargo-objcopy

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -42,7 +42,7 @@ $(IMAGE): $(BOOTBLOB) $(FIXED_DTFS)
 	@printf "**\n** Output: $@\n**\n"
 
 $(TARGET_DIR)/bootblob.bin: $(ELF)
-	RUST_TARGET_PATH=$(TOP)/src/custom_targets cargo objcopy --bin $(notdir $<) -- -O binary -R .bss $@
+	rust-objcopy -O binary -R .bss $< $@
 
 # Re-run cargo every time.
 .PHONY: $(ELF)


### PR DESCRIPTION
cargo-binutils v0.2.0 now tries to rebuild your crates which was
problematic when also using cargo-xbuild.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>