### PR TITLE
Pin rust toolchain to nightly-2020-04-22, the last known working version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ $(MAINBOARDS):
 	cd src/mainboard/$@ && make
 
 firsttime:
-	curl https://sh.rustup.rs -sSf | sh -s -- -y
-	rustup override set nightly
+	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2020-04-22
+	rustup override set nightly-2020-04-23
 	rustup component add rust-src llvm-tools-preview
 	rustup target add riscv64imac-unknown-none-elf
 	rustup target add riscv32imc-unknown-none-elf


### PR DESCRIPTION
Signed-off-by: Nickolas Fotopoulos <foton@google.com>