### PR TITLE
Fix compilation issues with qemu-armv7.

### DIFF
--- a/payloads/src/external/zimage/mod.rs
+++ b/payloads/src/external/zimage/mod.rs
@@ -1,12 +1,10 @@
-/*
-use crate::payload;
-
-const KERNEL: &'static [u8] = include_bytes!("zImage");
+pub const KERNEL: &'static [u8] = include_bytes!("zImage");
 pub const DTB: &'static [u8] = include_bytes!("qemu_fdt.dtb");
 
+/*
+use crate::payload;
 // TODO: Create a struct which tells you where the available memory is.
 const MEM: u32 = 0x40200000;
-
 // TODO: Parse from SPI.
 pub const PAYLOAD: payload::Payload = payload::Payload {
     typ: payload::ftype::CBFS_TYPE_RAW,

--- a/src/mainboard/emulation/qemu-armv7/src/main.rs
+++ b/src/mainboard/emulation/qemu-armv7/src/main.rs
@@ -19,7 +19,8 @@ use wrappers::{DoD, SliceReader};
 pub extern "C" fn _start() -> ! {
     let mut pl011 = uart::pl011::PL011::new(0x09000000, 115200);
     let uart_driver: &mut dyn Driver = &mut pl011;
-    uart_driver.init();
+    // TODO: Handle error here and quit, rather than unwrapping.
+    uart_driver.init().unwrap();
     uart_driver.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
     let s = &mut [uart_driver];
     let console = &mut DoD::new(s);

--- a/src/mainboard/emulation/qemu-armv7/src/romstage.rs
+++ b/src/mainboard/emulation/qemu-armv7/src/romstage.rs
@@ -1,8 +1,28 @@
 use crate::halt;
-use payloads::external::zimage::PAYLOAD;
+use payloads::external::zimage::{DTB, KERNEL};
+use payloads::payload;
+use wrappers::SliceReader;
+
+const MEM: usize = 0x40200000;
+const DTB_BASE: usize = MEM + 5 * KERNEL.len();
 
 pub fn romstage() -> ! {
-    let p = PAYLOAD;
+    let kernel_segs = &[
+        payload::Segment {
+            // Kernel segment
+            typ: payload::stype::PAYLOAD_SEGMENT_ENTRY,
+            base: MEM,
+            data: &mut SliceReader::new(KERNEL),
+        },
+        payload::Segment {
+            // Device tree segment
+            typ: payload::stype::PAYLOAD_SEGMENT_DATA,
+            // TODO: Assumes the decompression ratio is no more than 5x.
+            base: DTB_BASE,
+            data: &mut SliceReader::new(DTB),
+        },
+    ];
+    let mut p = payload::Payload { typ: payload::ftype::CBFS_TYPE_RAW, compression: payload::ctype::CBFS_COMPRESS_NONE, offset: 0, entry: 0, dtb: DTB_BASE, rom_len: KERNEL.len() as usize, mem_len: KERNEL.len() as usize, segs: kernel_segs };
     p.load();
     p.run();
 


### PR DESCRIPTION
This fixes the compilation issues with qemu-armv7 version but there is still a linker error related to the nostd usage. Plan is to fix the linker error in subsequent changes.

Linker error that remains is: 

note: rust-lld: warning: lld uses blx instruction, no object with architecture supporting feature detected
          rust-lld: error: undefined hidden symbol: __aeabi_uldivmod

#250 is the associated issue.