### PR TITLE
Pin cargo package versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ firsttime:
 	rustup target add riscv64imac-unknown-none-elf
 	rustup target add riscv32imc-unknown-none-elf
 	rustup target add armv7r-none-eabi
-	cargo install cargo-xbuild cargo-binutils
+	cargo install --version 0.5.29 cargo-xbuild
+	cargo install --version 0.2.0 cargo-binutils
 	sudo apt-get install device-tree-compiler pkg-config libssl-dev
 
 update:


### PR DESCRIPTION
Pin cargo-xbuild and cargo-binutils versions in `make firsttime`. In doing so, revert cargo-xbuild by three versions (0.5.32 &rarr; 0.5.29), which fixes #259. I verified that all newer versions are broken for us, but have not yet taken the time to figure out whether the five issues reported against cargo-xbuild in the relevant time period correspond to our breakage or not.