### PR TITLE
soc/sifive/fu540: Update QEMU detect logic

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ steps:
   displayName: 'Build QEMU q35 board for x86'
 - script: |
     set -e
-    git clone https://github.com/qemu/qemu && cd qemu && git checkout v4.2.0-rc3
+    git clone https://github.com/qemu/qemu && cd qemu && git checkout 171199f56f5f
     mkdir build-riscv64 && cd build-riscv64
     ../configure --target-list=riscv64-softmmu
     make -j16

--- a/src/soc/sifive/fu540/src/lib.rs
+++ b/src/soc/sifive/fu540/src/lib.rs
@@ -14,6 +14,6 @@ use core::ptr;
 
 // TODO: There might be a better way to detect whether we are running in QEMU.
 pub fn is_qemu() -> bool {
-    // On hardware, the MSEL is only 4 bits, so it is impossible for it to reach this value.
-    unsafe { ptr::read_volatile(reg::MSEL as *mut u32) == 0x297 }
+    // On hardware, the instruction at 0x1008 is 'lw t1, -4(t0)'.
+    unsafe { ptr::read_volatile(reg::QEMU_FLAG as *mut u32) == 0x01c28593 }
 }

--- a/src/soc/sifive/fu540/src/reg.rs
+++ b/src/soc/sifive/fu540/src/reg.rs
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  */
 
-pub const MSEL: u32 = 0x00001000;
+pub const QEMU_FLAG: u32 = 0x00001008;
 pub const DTIM: u32 = 0x01000000;
 pub const CLINT: u32 = 0x02000000;
 pub const L2_LIM: u32 = 0x08000000;


### PR DESCRIPTION
Current codes detect QEMU by inspecting a 32-bit value at address
0x1000 (which is the MSEL pin state). This worked as QEMU has not
implemented MSEL support yet. With MSEL supported [1] added in the
upstream QEMU recently, the detecting logic no longer works, and
we have to update the logic to look at the value at address 0x1008
instead, where QEMU differs from real hardware.

[1] http://patchwork.ozlabs.org/project/qemu-devel/patch/1592268641-7478-3-git-send-email-bmeng.cn@gmail.com/

Signed-off-by: Bin Meng <bin.meng@windriver.com>