### PR TITLE
Use wildcard to define list of mainboards.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,12 @@ help:
 	@echo '  # Build debug mode'
 	@echo '  MODE=debug make mainboards'
 
-BROKEN := src/mainboard/ast/ast25x0/Makefile
-# somebody else can figure this out. MAINBOARDS := $(filter-out $(wildcard src/mainboard/*/*/Makefile), $(BROKEN))
-MAINBOARDS := \
-	src/mainboard/emulation/qemu-armv7/Makefile \
-	src/mainboard/emulation/qemu-q35/Makefile \
-	src/mainboard/emulation/qemu-riscv/Makefile \
+BROKEN := \
+	src/mainboard/ast/ast25x0/Makefile \
 	src/mainboard/nuvoton/npcm7xx/Makefile \
-	src/mainboard/opentitan/crb/Makefile \
-	src/mainboard/sifive/hifive/Makefile \
+	src/mainboard/emulation/qemu-armv7/Makefile \
+
+MAINBOARDS := $(filter-out $(BROKEN), $(wildcard src/mainboard/*/*/Makefile))
 
 .PHONY: mainboards $(MAINBOARDS)
 mainboards: $(MAINBOARDS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,9 @@ steps:
     make --keep-going test
   displayName: 'Run rust tests'
 - script: |
+    make --keep-going mainboards
+  displayName: 'Build all mainboards'
+- script: |
     cd src/mainboard/sifive/hifive
     PAYLOAD_A=../../../../payloads/src/external/simple/testtesttest make
   displayName: 'Build SiFive board for RISC-V'


### PR DESCRIPTION
The problem was the ordering of arguments inside filter-out function (in
the comment the arguments were in invalid order which is why it was not
working).

I am adding emulation/qemu-armv7 and nuvoton/npcm7xx to the list of
broken targets because they fail to build.