### PR TITLE
Use generics instead of trait objects in FdtReader

### DIFF
--- a/src/drivers/wrappers/src/lib.rs
+++ b/src/drivers/wrappers/src/lib.rs
@@ -93,19 +93,19 @@ impl<'a> Driver for SliceReader<'a> {
 }
 
 /// The driver reads from a section (offset+size) of another driver.
-pub struct SectionReader<'a> {
-    driver: &'a dyn Driver,
+pub struct SectionReader<'a, D: Driver> {
+    driver: &'a D,
     offset: usize,
     size: usize,
 }
 
-impl<'a> SectionReader<'a> {
-    pub fn new(driver: &'a dyn Driver, offset: usize, size: usize) -> SectionReader {
+impl<'a, D: Driver> SectionReader<'a, D> {
+    pub fn new(driver: &'a D, offset: usize, size: usize) -> SectionReader<D> {
         SectionReader { driver, offset, size }
     }
 }
 
-impl<'a> Driver for SectionReader<'a> {
+impl<'a, D: Driver> Driver for SectionReader<'a, D> {
     fn pread(&self, data: &mut [u8], pos: usize) -> Result<usize> {
         if pos >= self.size {
             return EOF;

--- a/src/lib/device_tree/src/lib.rs
+++ b/src/lib/device_tree/src/lib.rs
@@ -109,20 +109,20 @@ impl Path {
 /// In-memory reader for Flattened Device Tree format.
 ///
 /// Does not perform any sanity checks.
-pub struct FdtReader<'a> {
-    _mem_reservation_block: SectionReader<'a>,
-    struct_block: SectionReader<'a>,
-    strings_block: SectionReader<'a>,
+pub struct FdtReader<'a, D: Driver> {
+    _mem_reservation_block: SectionReader<'a, D>,
+    struct_block: SectionReader<'a, D>,
+    strings_block: SectionReader<'a, D>,
 }
 
-fn cursor_u32(drv: &dyn Driver, cursor: &mut usize) -> Result<u32> {
+fn cursor_u32(drv: &impl Driver, cursor: &mut usize) -> Result<u32> {
     let mut data = [0; 4];
     *cursor += drv.pread(&mut data, *cursor)?;
     Ok(BigEndian::read_u32(&data))
 }
 
 // Reads a string (including null-terminator). Returns bytes read.
-fn cursor_string(drv: &dyn Driver, cursor: &mut usize, buf: &mut [u8]) -> Result<usize> {
+fn cursor_string(drv: &impl Driver, cursor: &mut usize, buf: &mut [u8]) -> Result<usize> {
     for i in 0..buf.len() {
         *cursor += drv.pread(&mut buf[i..i + 1], *cursor)?;
         if buf[i] == 0 {
@@ -137,7 +137,7 @@ fn align4(x: usize) -> usize {
 }
 
 // Reads the header of the device tree.
-fn read_fdt_header(drv: &dyn Driver) -> Result<FdtHeader> {
+fn read_fdt_header(drv: &impl Driver) -> Result<FdtHeader> {
     // 10 fields, each field 4 bytes.
     const HEADER_SIZE: usize = 10 * 4;
 
@@ -171,25 +171,25 @@ fn read_fdt_header(drv: &dyn Driver) -> Result<FdtHeader> {
     return Ok(header);
 }
 
-impl<'a> FdtReader<'a> {
-    pub fn new(drv: &'a dyn Driver) -> Result<FdtReader<'a>> {
+impl<'a, D: Driver> FdtReader<'a, D> {
+    pub fn new(drv: &'a D) -> Result<FdtReader<'a, D>> {
         let header = read_fdt_header(drv)?;
 
-        Ok(FdtReader::<'a> {
+        Ok(FdtReader {
             _mem_reservation_block: SectionReader::new(drv, header.off_mem_rsvmap as usize, (header.total_size - header.off_dt_struct) as usize),
             struct_block: SectionReader::new(drv, header.off_dt_struct as usize, header.size_dt_struct as usize),
             strings_block: SectionReader::new(drv, header.off_dt_strings as usize, header.size_dt_strings as usize),
         })
     }
 
-    pub fn walk(&'a self) -> FdtIterator<'a> {
+    pub fn walk(&'a self) -> FdtIterator<'a, D> {
         FdtIterator { dt: self, cursor: 0, depth: 0, len_buf: [0; MAX_DEPTH], path_buf: [[0; MAX_NAME_SIZE]; MAX_DEPTH] }
     }
 }
 
 /// Iterator used to walk through device tree representation.
-pub struct FdtIterator<'a> {
-    dt: &'a FdtReader<'a>,
+pub struct FdtIterator<'a, D: Driver> {
+    dt: &'a FdtReader<'a, D>,
     cursor: usize,
     depth: usize,
     len_buf: [usize; MAX_DEPTH],
@@ -197,10 +197,10 @@ pub struct FdtIterator<'a> {
 }
 
 // TODO: how to return errors from an iterator?
-impl<'a> Iterator for FdtIterator<'a> {
-    type Item = Entry<'a>;
+impl<'a, D: Driver> Iterator for FdtIterator<'a, D> {
+    type Item = Entry<'a, SectionReader<'a, D>>;
 
-    fn next(&mut self) -> Option<Entry<'a>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             let op = num_traits::cast::FromPrimitive::from_u32(cursor_u32(&self.dt.struct_block, &mut self.cursor).unwrap());
             match op {
@@ -227,7 +227,7 @@ impl<'a> Iterator for FdtIterator<'a> {
                     let value = SectionReader::new(&self.dt.struct_block, self.cursor, len);
                     self.cursor = align4(self.cursor + len);
                     // Note: This performs a copy of the whole path_buf array!
-                    return Some(Entry::Property::<'a> { path: Path { depth: self.depth + 1, len: self.len_buf, buf: self.path_buf }, value: value });
+                    return Some(Entry::Property { path: Path { depth: self.depth + 1, len: self.len_buf, buf: self.path_buf }, value: value });
                 }
                 Some(Token::Nop) => continue,
                 Some(Token::End) => return None,
@@ -237,9 +237,9 @@ impl<'a> Iterator for FdtIterator<'a> {
     }
 }
 
-pub enum Entry<'a> {
+pub enum Entry<'a, D: Driver> {
     Node { path: Path },
-    Property { path: Path, value: SectionReader<'a> },
+    Property { path: Path, value: SectionReader<'a, D> },
 }
 
 /// Typed value of device tree properties.

--- a/src/lib/device_tree/tests/integration_test.rs
+++ b/src/lib/device_tree/tests/integration_test.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 use wrappers::SliceReader;
 
-fn assert_node(entry: Entry, name: &str, depth: usize) {
+fn assert_node<D: Driver>(entry: Entry<D>, name: &str, depth: usize) {
     if let Entry::Node { path } = entry {
         assert_eq!(path.name(), name);
         assert_eq!(path.depth(), depth);
@@ -15,7 +15,7 @@ fn assert_node(entry: Entry, name: &str, depth: usize) {
     }
 }
 
-fn assert_property(entry: Entry, expected_name: &str, expected_depth: usize, expected_value: &[u8]) {
+fn assert_property<D: Driver>(entry: Entry<D>, expected_name: &str, expected_depth: usize, expected_value: &[u8]) {
     if let Entry::Property { path, value } = entry {
         assert_eq!(path.name(), expected_name);
         assert_eq!(path.depth(), expected_depth);
@@ -35,7 +35,7 @@ fn dts_to_dtb(dts: &str) -> std::vec::Vec<u8> {
     panic!("dtc command failed: {:?}", String::from_utf8_lossy(&output.stderr))
 }
 
-fn read_all(d: &dyn Driver) -> std::vec::Vec<u8> {
+fn read_all(d: &impl Driver) -> std::vec::Vec<u8> {
     let mut data = [0; 500];
     let size = d.pread(&mut data, 0).unwrap();
     let mut result = std::vec::Vec::new();

--- a/src/mainboard/sifive/hifive/src/main.rs
+++ b/src/mainboard/sifive/hifive/src/main.rs
@@ -175,7 +175,7 @@ fn test_ddr(addr: *mut u32, size: usize, w: &mut print::WriteTo) -> Result<(), (
 }
 
 // TODO: move out of mainboard
-pub fn print_fdt(fdt: &mut dyn Driver, w: &mut print::WriteTo) -> Result<(), &'static str> {
+pub fn print_fdt(fdt: &mut impl Driver, w: &mut print::WriteTo) -> Result<(), &'static str> {
     for entry in FdtReader::new(fdt)?.walk() {
         match entry {
             Entry::Node { path: p } => {


### PR DESCRIPTION
ref #38

Generics allow us to avoid dynamic dispatch and should make the code
faster.

Signed-off-by: Tomasz Zurkowski <zurkowski@google.com>