### PR TITLE
Makefile: separate prepare target for CI from firsttime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ MAINBOARDS := \
 	src/mainboard/opentitan/crb/Makefile \
 	src/mainboard/sifive/hifive/Makefile \
 
+TOOLCHAIN_VER := nightly-2020-04-22
+XBUILD_VER := 0.5.29
+BINUTILS_VER := 0.2.0
+
 .PHONY: mainboards $(MAINBOARDS)
 mainboards: $(MAINBOARDS)
 
@@ -31,15 +35,20 @@ $(MAINBOARDS):
 	cd $(dir $@) && make
 
 firsttime:
-	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2020-04-22
-	rustup override set nightly-2020-04-23
+	rustup override set $(TOOLCHAIN_VER)
 	rustup component add rust-src llvm-tools-preview rustfmt
 	rustup target add riscv64imac-unknown-none-elf
 	rustup target add riscv32imc-unknown-none-elf
 	rustup target add armv7r-none-eabi
-	cargo install --version 0.5.29 cargo-xbuild
-	cargo install --version 0.2.0 cargo-binutils
+	cargo install $(if $(XBUILD_VER),--version $(XBUILD_VER),) cargo-xbuild
+	cargo install $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
+
+debiansysprepare:
 	sudo apt-get install device-tree-compiler pkg-config libssl-dev
+	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $(TOOLCHAIN_VER)
+
+.PHONY: ciprepare debiansysprepare firsttime
+ciprepare: debiansysprepare firsttime
 
 update:
 	rustup update

--- a/README.md
+++ b/README.md
@@ -26,17 +26,39 @@ Oreboot+QEMU for ARM:
 Getting oreboot
 ---------------
 
-Clone this repo, e.g. git clone git://github.com/oreboot/oreboot
+Clone this repo and enter its directory, i.e.:
 
-
-Setting up build tools
-----------------------
-
-Setup your Rust environment for oreboot:
-
-```
+```sh
+git clone git://github.com/oreboot/oreboot
 cd oreboot
-# This command only needs to be done once but it is safe to do it repeatedly
+```
+
+Prerequisites
+-------------
+
+In general, you will need the following packages installed:
+
+- `device-tree-compiler`
+- `pkg-config`
+- `libssl`
+- `rustup`
+
+For Debian based systems, there is a make target to install those, which pulls
+`rustup` through curl from https://sh.rustup.rs:
+
+```sh
+make debiansysprepare
+```
+
+Otherwise, install the package through your system package manager.
+
+Setting up the toolchain
+------------------------
+
+Regardless of your OS, you will need to install the toolchain for oreboot.
+This command only needs to be done once but it is safe to do it repeatedly.
+
+```sh
 make firsttime
 ```
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pool:
 
 steps:
 - script: |
-    make firsttime
+    make ciprepare
   displayName: 'Install Rust Dependencies'
 - script: |
     make --keep-going format check=true


### PR DESCRIPTION
This also introduces variables to switch tooling versions.

Signed-off-by: Daniel Maslowski <info@orangecms.org>