### PR TITLE
Add `make clippy`, fix existing warnings and run in CI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(MAINBOARDS):
 
 firsttime:
 	rustup override set $(TOOLCHAIN_VER)
-	rustup component add rust-src llvm-tools-preview rustfmt
+	rustup component add rust-src llvm-tools-preview rustfmt clippy
 	rustup target add riscv64imac-unknown-none-elf
 	rustup target add riscv32imc-unknown-none-elf
 	rustup target add armv7r-none-eabi
@@ -93,6 +93,13 @@ $(CRATES_TO_TEST):
 	cd $(dir $@) && cargo test
 .PHONY: test $(CRATES_TO_TEST)
 test: $(CRATES_TO_TEST)
+
+# TODO: Fix payloads crate and remove "-A clippy::module-inception" exception.
+CRATES_TO_CLIPPY := $(patsubst %/Cargo.toml,%/Cargo.toml.clippy,$(filter-out $(BROKEN_CRATES_TO_TEST),$(CRATES)))
+$(CRATES_TO_CLIPPY):
+	cd $(dir $@) && cargo clippy -- -D warnings -A clippy::module-inception
+.PHONY: clippy $(CRATES_TO_CLIPPY)
+clippy: $(CRATES_TO_CLIPPY)
 
 clean:
 	rm -rf $(wildcard src/mainboard/*/*/target)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,9 @@ steps:
     make --keep-going test
   displayName: 'Run rust tests'
 - script: |
+    make --keep-going clippy
+  displayName: 'Run clippy linter'
+- script: |
     make --keep-going mainboards
   displayName: 'Build all mainboards'
 - script: |

--- a/payloads/src/external/zimage/mod.rs
+++ b/payloads/src/external/zimage/mod.rs
@@ -1,5 +1,5 @@
-pub const KERNEL: &'static [u8] = include_bytes!("zImage");
-pub const DTB: &'static [u8] = include_bytes!("qemu_fdt.dtb");
+pub const KERNEL: &[u8] = include_bytes!("zImage");
+pub const DTB: &[u8] = include_bytes!("qemu_fdt.dtb");
 
 /*
 use crate::payload;

--- a/src/arch/x86/x86_64/src/ioport.rs
+++ b/src/arch/x86/x86_64/src/ioport.rs
@@ -15,7 +15,7 @@ fn inb(port: u16) -> u8 {
     unsafe {
         llvm_asm!("inb %dx, %al" : "={ax}"(ret) : "{dx}"(port) :: "volatile");
     }
-    return ret;
+    ret
 }
 
 // /// Write 16 bits to port

--- a/src/drivers/sifive/spi/src/lib.rs
+++ b/src/drivers/sifive/spi/src/lib.rs
@@ -266,7 +266,7 @@ register_bitfields! {
 
 impl SiFiveSpi {
     pub fn new(base: usize, serial_rate: u32) -> SiFiveSpi {
-        SiFiveSpi { base: base, serial_rate: serial_rate }
+        SiFiveSpi { base, serial_rate }
     }
 
     /// Returns a pointer to the register block

--- a/src/lib/device_tree/src/lib.rs
+++ b/src/lib/device_tree/src/lib.rs
@@ -168,7 +168,7 @@ fn read_fdt_header(drv: &impl Driver) -> Result<FdtHeader> {
     if header.magic != MAGIC {
         return Err("invalid magic in device tree header");
     }
-    return Ok(header);
+    Ok(header)
 }
 
 impl<'a, D: Driver> FdtReader<'a, D> {
@@ -227,7 +227,7 @@ impl<'a, D: Driver> Iterator for FdtIterator<'a, D> {
                     let value = SectionReader::new(&self.dt.struct_block, self.cursor, len);
                     self.cursor = align4(self.cursor + len);
                     // Note: This performs a copy of the whole path_buf array!
-                    return Some(Entry::Property { path: Path { depth: self.depth + 1, len: self.len_buf, buf: self.path_buf }, value: value });
+                    return Some(Entry::Property { path: Path { depth: self.depth + 1, len: self.len_buf, buf: self.path_buf }, value });
                 }
                 Some(Token::Nop) => continue,
                 Some(Token::End) => return None,
@@ -270,7 +270,7 @@ impl<'a> core::fmt::Display for Type<'a> {
 /// bytes. Because of this unambiguity, this method should only be used to print the content of the
 /// data to user.
 pub fn infer_type(data: &[u8]) -> Type {
-    if data.len() == 0 {
+    if data.is_empty() {
         return Type::Empty;
     }
     if let Some(i) = data.iter().position(|&c| !is_print(c)) {

--- a/src/lib/print/src/lib.rs
+++ b/src/lib/print/src/lib.rs
@@ -9,7 +9,7 @@ pub struct WriteTo<'a> {
 
 impl<'a> WriteTo<'a> {
     pub fn new(drv: &'a mut dyn Driver) -> Self {
-        WriteTo { drv: drv }
+        WriteTo { drv }
     }
 }
 

--- a/tools/layoutflash/src/main.rs
+++ b/tools/layoutflash/src/main.rs
@@ -82,7 +82,7 @@ fn layout_flash(path: &Path, areas: &mut [Area]) -> io::Result<()> {
         let mut v = Vec::new();
         v.resize(a.size as usize, 0xff);
         f.seek(SeekFrom::Start(a.offset as u64))?;
-        f.write(&v)?;
+        f.write_all(&v)?;
 
         // If a file is specified, write the file.
         if let Some(path) = &a.file {
@@ -93,7 +93,7 @@ fn layout_flash(path: &Path, areas: &mut [Area]) -> io::Result<()> {
             }
 
             // If the path is an unused environment variable, skip it.
-            if path.starts_with("$(") && path.ends_with(")") {
+            if path.starts_with("$(") && path.ends_with(')') {
                 continue;
             }
 
@@ -105,7 +105,7 @@ fn layout_flash(path: &Path, areas: &mut [Area]) -> io::Result<()> {
             if data.len() > a.size as usize {
                 return Err(io::Error::new(io::ErrorKind::InvalidData, format!("File {} is too big to fit into the flash area, file size: {}, area size: {}", path, data.len(), a.size)));
             }
-            f.write(&data)?;
+            f.write_all(&data)?;
         }
     }
     Ok(())


### PR DESCRIPTION
Clippy is a standard lint tool for rust, for more information see https://github.com/rust-lang/rust-clippy.

Closes #282

