### PR TITLE
Generate the report of binary sizes in CI.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,9 @@ steps:
     make --keep-going mainboards
   displayName: 'Build all mainboards'
 - script: |
+    ./scripts/generate-size-report.sh
+  displayName: 'Generate report of binary sizes'
+- script: |
     cd src/mainboard/sifive/hifive
     PAYLOAD_A=../../../../payloads/src/external/simple/testtesttest make
   displayName: 'Build SiFive board for RISC-V'

--- a/scripts/generate-size-report.sh
+++ b/scripts/generate-size-report.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "Mainboard;Size(bytes)"
+for BOOTBLOB in $(find . -name bootblob.bin)
+do
+  SIZE=$(stat -c"%s" $BOOTBLOB)
+  if [[ $BOOTBLOB =~ \./src/mainboard/([^/]+)/([^/]+).* ]]; then 
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]};${SIZE}"
+  fi 
+done


### PR DESCRIPTION
This new script will print a simple CSV with two columns - the name of
the mainboard (two directory names) and the size of the bootblob in
bytes.

It would be nice to export this data in strucutre manner somewhere and
track over time, but for now at least we will have this information in
the azure pipeline logs.

Signed-off-by: Tomasz Zurkowski <zurkowski@google.com>