### PR TITLE
Add more tests for device tree reader.

### DIFF
--- a/src/drivers/wrappers/src/lib.rs
+++ b/src/drivers/wrappers/src/lib.rs
@@ -82,7 +82,7 @@ impl<'a> Driver for SliceReader<'a> {
         }
         let count = data.len().min(self.data.len() - pos);
         data[..count].copy_from_slice(&self.data[pos..pos + count]);
-        Ok(data.len())
+        Ok(count)
     }
 
     fn pwrite(&mut self, _data: &[u8], _pos: usize) -> Result<usize> {

--- a/src/drivers/wrappers/tests/tests.rs
+++ b/src/drivers/wrappers/tests/tests.rs
@@ -32,21 +32,30 @@ fn test_slice_reader_returns_zero_for_empty_buf() {
 }
 
 #[test]
-#[should_panic]
+fn test_slice_reader_returns_number_of_bytes_read() {
+    let data = [1, 2, 3, 4, 5];
+    let driver = SliceReader::new(&data);
+    let mut buf = [0; 10];
+
+    assert_eq!(5, driver.pread(&mut buf, 0).unwrap());
+    assert_eq!(&buf[..5], &data);
+    assert_eq!(&buf[5..], &[0; 5]);
+}
+
+#[test]
 fn test_slice_reader_returns_eof() {
     let data = [1, 2, 3, 4, 5];
     let driver = SliceReader::new(&data);
     let mut buf = [0; 5];
 
-    driver.pread(&mut buf, 5).unwrap();
+    assert_eq!(driver.pread(&mut buf, 5).err(), Some("EOF"));
 }
 
 #[test]
-#[should_panic]
 fn test_slice_reader_returns_eof_with_empty_buf() {
     let data = [1, 2, 3, 4, 5];
     let driver = SliceReader::new(&data);
     let mut buf = [0; 0];
 
-    driver.pread(&mut buf, 5).unwrap();
+    assert_eq!(driver.pread(&mut buf, 5).err(), Some("EOF"));
 }


### PR DESCRIPTION
While writing tests, I found that there is a bug in SliceReader (it
always returns the size of the input buffer instead of the number of
bytes actually read).

Closes #156 - existing tests cover various cases, including nested
nodes, different type of properties (empty, number, string) and few
error conditions.

Closes #155 - added test cases for empty properties and shows it works
(though because of Driver API, when property is empty the Driver returns
EOF error, but that is WAI).

Signed-off-by: Tomasz Zurkowski <zurkowski@google.com>