### PR TITLE
Compute the offset based on previous areas.

### DIFF
--- a/src/mainboard/sifive/hifive/fixed-dtfs.dts
+++ b/src/mainboard/sifive/hifive/fixed-dtfs.dts
@@ -12,37 +12,31 @@
         areas {
             area@0 {
                 description = "Boot Blob and Ramstage";
-                offset = <0x0>;
                 size = <0x80000>; // 512KiB
                 file = "$(TARGET_DIR)/bootblob.bin";
             };
             area@1 {
                 description = "Fixed DTFS";
-                offset = <0x80000>;
                 size = <0x80000>; // 512KiB
                 file = "$(TARGET_DIR)/fixed-dtfs.dtb";
             };
             area@2 {
                 description = "Payload A";
-                offset = <0x100000>;
                 size = <0x600000>; // 6MiB
                 file = "$(PAYLOAD_A)";
             };
             area@3 {
                 description = "Payload B";
-                offset = <0x700000>;
                 size = <0x600000>; // 6MiB
                 file = "$(PAYLOAD_B)";
             };
             area@4 {
                 description = "Payload C";
-                offset = <0xd00000>;
                 size = <0x300000>; // 3MiB
                 file = "$(PAYLOAD_C)";
             };
             area@5 {
                 description = "Empty Space";
-                offset = <0x1000000>;
                 size = <0x1000000>; // 16MiB
             };
         };


### PR DESCRIPTION
Closes #167 - make `offset` property optional inside fixed-dtfs used by
layoutflash. If not set, the end of the previous area will be used as
offset.