### PR TITLE
Refactor FdtIterator to use streaming iterator API.

### DIFF
--- a/src/lib/device_tree/Cargo.toml
+++ b/src/lib/device_tree/Cargo.toml
@@ -9,6 +9,7 @@ byteorder = { version = "1", default-features = false }
 model = { path = "../../drivers/model"}
 num-derive = { version = "0.2", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+print = { path = "../../lib/print" }
 wrappers = { path = "../../drivers/wrappers"}
 
 [profile.release]

--- a/src/lib/device_tree/tests/integration_test.rs
+++ b/src/lib/device_tree/tests/integration_test.rs
@@ -1,27 +1,35 @@
 extern crate device_tree;
 
 use device_tree::{Entry, FdtReader};
-use model::Driver;
+use model::{Driver, Result};
 use std::io::Write;
 use std::process::{Command, Stdio};
 use wrappers::SliceReader;
 
-fn assert_node<D: Driver>(entry: Entry<D>, name: &str, depth: usize) {
-    if let Entry::Node { path } = entry {
-        assert_eq!(path.name(), name);
-        assert_eq!(path.depth(), depth);
+fn assert_start_node<D: Driver>(entry: Option<Result<Entry<D>>>, expected_name: &str) {
+    let entry = entry.unwrap().unwrap();
+    if let Entry::StartNode { name } = entry {
+        assert_eq!(name, expected_name);
     } else {
-        panic!("Expected Node!")
+        panic!("Expected StartNode!")
     }
 }
 
-fn assert_property<D: Driver>(entry: Entry<D>, expected_name: &str, expected_depth: usize, expected_value: &[u8]) {
-    if let Entry::Property { path, value } = entry {
-        assert_eq!(path.name(), expected_name);
-        assert_eq!(path.depth(), expected_depth);
+fn assert_end_node<D: Driver>(entry: Option<Result<Entry<D>>>) {
+    let entry = entry.unwrap().unwrap();
+    if let Entry::EndNode = entry {
+    } else {
+        panic!("Expected EndNode!")
+    }
+}
+
+fn assert_property<D: Driver>(entry: Option<Result<Entry<D>>>, expected_name: &str, expected_value: &[u8]) {
+    let entry = entry.unwrap().unwrap();
+    if let Entry::Property { name, value } = entry {
+        assert_eq!(name, expected_name);
         assert_eq!(read_all(&value), expected_value);
     } else {
-        panic!("Expected Node!")
+        panic!("Expected Property!")
     }
 }
 
@@ -55,7 +63,8 @@ fn test_reads_empty_device_tree() {
     let reader = FdtReader::new(slice_reader).unwrap();
     let mut it = reader.walk();
 
-    assert_node(it.next().unwrap(), "", 1);
+    assert_start_node(it.next(), "");
+    assert_end_node(it.next());
     assert!(it.next().is_none());
 }
 
@@ -72,8 +81,9 @@ fn test_reads_properties() {
     let reader = FdtReader::new(slice_reader).unwrap();
     let mut it = reader.walk();
 
-    assert_node(it.next().unwrap(), "", 1);
-    assert_property(it.next().unwrap(), "#address-cells", 2, &vec![0, 0, 0, 1]);
+    assert_start_node(it.next(), "");
+    assert_property(it.next(), "#address-cells", &vec![0, 0, 0, 1]);
+    assert_end_node(it.next());
     assert!(it.next().is_none());
 }
 
@@ -90,8 +100,9 @@ fn test_reads_empty_properties() {
     let reader = FdtReader::new(slice_reader).unwrap();
     let mut it = reader.walk();
 
-    assert_node(it.next().unwrap(), "", 1);
-    assert_property(it.next().unwrap(), "#address-cells", 2, &vec![]);
+    assert_start_node(it.next(), "");
+    assert_property(it.next(), "#address-cells", &vec![]);
+    assert_end_node(it.next());
     assert!(it.next().is_none());
 }
 
@@ -114,11 +125,15 @@ fn test_reads_nested_nodes() {
     let reader = FdtReader::new(slice_reader).unwrap();
     let mut it = reader.walk();
 
-    assert_node(it.next().unwrap(), "", 1);
-    assert_node(it.next().unwrap(), "node1", 2);
-    assert_property(it.next().unwrap(), "#address-cells", 3, &vec![111, 107, 0]);
-    assert_node(it.next().unwrap(), "node2", 3);
-    assert_node(it.next().unwrap(), "node3", 2);
+    assert_start_node(it.next(), "");
+    assert_start_node(it.next(), "node1");
+    assert_property(it.next(), "#address-cells", &vec![111, 107, 0]);
+    assert_start_node(it.next(), "node2");
+    assert_end_node(it.next());
+    assert_end_node(it.next());
+    assert_start_node(it.next(), "node3");
+    assert_end_node(it.next());
+    assert_end_node(it.next());
     assert!(it.next().is_none());
 }
 

--- a/src/mainboard/amd/romecrb/Cargo.lock
+++ b/src/mainboard/amd/romecrb/Cargo.lock
@@ -5,6 +5,8 @@ name = "arch"
 version = "0.1.0"
 dependencies = [
  "model",
+ "print",
+ "wrappers",
 ]
 
 [[package]]

--- a/src/mainboard/sifive/hifive/Cargo.lock
+++ b/src/mainboard/sifive/hifive/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "model 0.1.0",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "print 0.1.0",
  "wrappers 0.1.0",
 ]
 

--- a/src/mainboard/sifive/hifive/src/main.rs
+++ b/src/mainboard/sifive/hifive/src/main.rs
@@ -10,8 +10,8 @@ use core::intrinsics::transmute;
 use core::panic::PanicInfo;
 use core::sync::atomic::{spin_loop_hint, AtomicUsize, Ordering};
 use core::{fmt::Write, ptr};
-use device_tree::{infer_type, Entry, FdtReader};
-use model::{Driver, EOF};
+use device_tree::print_fdt;
+use model::Driver;
 use payloads::payload;
 use print;
 use soc::clock::Clock;
@@ -169,36 +169,6 @@ fn test_ddr(addr: *mut u32, size: usize, w: &mut print::WriteTo) -> Result<(), (
         let v = unsafe { ptr::read(addr.add(i)) };
         if v != i as u32 + 1 {
             return Err((unsafe { addr.add(i) }, v));
-        }
-    }
-    Ok(())
-}
-
-// TODO: move out of mainboard
-pub fn print_fdt(fdt: &mut impl Driver, w: &mut print::WriteTo) -> Result<(), &'static str> {
-    let reader = FdtReader::new(fdt)?;
-    let mut iter = reader.walk();
-    let mut depth = 0;
-    while let Some(entry) = iter.next() {
-        let entry = entry?;
-        match entry {
-            Entry::StartNode { name } => {
-                depth += 1;
-                write!(w, "{:depth$}{}\r\n", "", name, depth = depth * 2).unwrap();
-            }
-            Entry::EndNode {} => {
-                depth -= 1;
-            }
-            Entry::Property { name, value: v } => {
-                let buf = &mut [0; 1024];
-                let len = match v.pread(buf, 0) {
-                    Ok(x) => x,
-                    EOF => 0,
-                    Err(y) => return Err(y),
-                };
-                let val = infer_type(&buf[..len]);
-                write!(w, "{:depth$}{} = {}\r\n", "", name, val, depth = depth * 2,).unwrap();
-            }
         }
     }
     Ok(())

--- a/tools/layoutflash/Cargo.lock
+++ b/tools/layoutflash/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "model 0.1.0",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "print 0.1.0",
  "wrappers 0.1.0",
 ]
 
@@ -137,6 +138,13 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "print"
+version = "0.1.0"
+dependencies = [
+ "model 0.1.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #74.

We are dropping the core::Iterator trait from `FdtIterator` as we never
actually benefited from implementing it. Implementing next with custom
lifetimes allows us to make it more performant (`Entry` can reference
internal buffers in `FdtIterator`).

I am also adding error handling to the `FdtIterator` following
`std::io::Lines` approach. I also removed the use of unsafe from device
tree crate (we check if string is indeed utf8 and return error if it is
not).

I also slightly changed the API of Entry to include both StartNode and
EndNode. This is following similar pattern to StAX XML parsers and
allows users of the iterator to write more composable code.

Signed-off-by: Tomasz Zurkowski <zurkowski@google.com>