### PR TITLE
Add unit test to i8250 driver and remove unused code

### DIFF
--- a/src/drivers/uart/Cargo.toml
+++ b/src/drivers/uart/Cargo.toml
@@ -17,9 +17,9 @@ register = "0.3.2"
 optional = true
 
 [features]
-i8250 = []
+i8250 = ["heapless"]
 pl011 = []
 ns16550 = []
 sifive = []
-log = []
+log = ["heapless"]
 opentitan = []

--- a/src/drivers/uart/src/i8250.rs
+++ b/src/drivers/uart/src/i8250.rs
@@ -74,7 +74,7 @@ impl<'a> Driver for I8250<'a> {
     fn pread(&self, data: &mut [u8], _offset: usize) -> Result<usize> {
         for c in data.iter_mut() {
             let mut s = [0u8; 1];
-            while self.poll_status(1, 1) {}
+            while !self.poll_status(1, 1) {}
             self.d.pread(&mut s, self.base).unwrap();
             *c = s[0];
         }
@@ -84,7 +84,7 @@ impl<'a> Driver for I8250<'a> {
     fn pwrite(&mut self, data: &[u8], _offset: usize) -> Result<usize> {
         for (_i, &c) in data.iter().enumerate() {
             // Poll the status for long enough to let a char out; then push it out anyway.
-            self.poll_status(2, 2);
+            while !self.poll_status(0x20, 0x20) && !self.poll_status(0x40, 0x40) {}
             let mut s = [0u8; 1];
             s[0] = c;
             self.d.pwrite(&s, self.base).unwrap();

--- a/src/drivers/uart/src/lib.rs
+++ b/src/drivers/uart/src/lib.rs
@@ -15,3 +15,8 @@ pub mod opentitan;
 pub mod pl011;
 #[cfg(feature = "sifive")]
 pub mod sifive;
+
+/* Calculate divisor. Do not floor but round to nearest integer. */
+pub fn uart_baudrate_divisor(baudrate: usize, refclk: usize, oversample: usize) -> usize {
+    (1 + (2 * refclk) / (baudrate * oversample)) / 2
+}

--- a/src/drivers/uart/src/lib.rs
+++ b/src/drivers/uart/src/lib.rs
@@ -15,8 +15,3 @@ pub mod opentitan;
 pub mod pl011;
 #[cfg(feature = "sifive")]
 pub mod sifive;
-
-/* Calculate divisor. Do not floor but round to nearest integer. */
-pub fn uart_baudrate_divisor(baudrate: usize, refclk: usize, oversample: usize) -> usize {
-    (1 + (2 * refclk) / (baudrate * oversample)) / 2
-}

--- a/src/mainboard/amd/romecrb/Cargo.lock
+++ b/src/mainboard/amd/romecrb/Cargo.lock
@@ -238,6 +238,7 @@ name = "uart"
 version = "0.1.0"
 dependencies = [
  "clock",
+ "heapless 0.4.4",
  "model",
  "register",
 ]


### PR DESCRIPTION
Unfortunately i8250 is port mapped so I am unable to use register blocks.
I still managed to add some unit test to check that the driver initialises the UART.