### PR TITLE
Add Driver::pread_exact method.

### DIFF
--- a/src/drivers/model/src/lib.rs
+++ b/src/drivers/model/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![deny(warnings)]
 
 pub type Result<T> = core::result::Result<T, &'static str>;
 
@@ -20,4 +19,22 @@ pub trait Driver {
     fn pwrite(&mut self, data: &[u8], pos: usize) -> Result<usize>;
     /// Shutdown the device.
     fn shutdown(&mut self);
+    /// Reads the exact number of bytes to fill in the `data`.
+    /// Returns ok if `data` is empty.
+    fn pread_exact(&self, mut data: &mut [u8], mut pos: usize) -> Result<()> {
+        while !data.is_empty() {
+            match self.pread(&mut data, pos) {
+                Ok(0) => return Err("unexpected eof"),
+                Ok(x) => {
+                    data = &mut data[x..];
+                    pos += x;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(())
+    }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/drivers/model/src/tests.rs
+++ b/src/drivers/model/src/tests.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+pub struct OneByteRead<'a> {
+    buf: &'a [u8],
+}
+
+impl<'a> Driver for OneByteRead<'a> {
+    fn pread(&self, data: &mut [u8], pos: usize) -> Result<usize> {
+        if pos >= self.buf.len() {
+            return EOF;
+        }
+        if data.len() == 0 {
+            return Ok(0);
+        }
+        data[0] = self.buf[pos];
+        Ok(1)
+    }
+    fn pwrite(&mut self, _data: &[u8], _pos: usize) -> Result<usize> {
+        Err("not implemented")
+    }
+    fn shutdown(&mut self) {}
+}
+
+#[test]
+fn pread_exact_reads_all_bytes() {
+    let data: [u8; 4] = [1, 2, 3, 4];
+    let drv = OneByteRead { buf: &data };
+
+    let mut got: [u8; 3] = [0, 0, 0];
+    drv.pread_exact(&mut got, 0).unwrap();
+    assert_eq!(data[0..3], got);
+}
+
+#[test]
+fn pread_exact_reads_all_bytes_from_custom_position() {
+    let data: [u8; 4] = [1, 2, 3, 4];
+    let drv = OneByteRead { buf: &data };
+
+    let mut got: [u8; 3] = [0, 0, 0];
+    drv.pread_exact(&mut got, 1).unwrap();
+    assert_eq!(data[1..4], got);
+}
+
+#[test]
+fn pread_exact_returns_ok_for_empty_data_buf() {
+    let data: [u8; 4] = [1, 2, 3, 4];
+    let drv = OneByteRead { buf: &data };
+
+    let mut got: [u8; 0] = [];
+    drv.pread_exact(&mut got, 10).unwrap();
+}
+
+#[test]
+fn pread_exact_returns_eof_when_not_enough_bytes_available() {
+    let data: [u8; 4] = [1, 2, 3, 4];
+    let drv = OneByteRead { buf: &data };
+
+    let mut got: [u8; 5] = [0, 0, 0, 0, 0];
+    assert_eq!(drv.pread_exact(&mut got, 0).err(), Some("EOF"));
+}

--- a/src/lib/device_tree/src/lib.rs
+++ b/src/lib/device_tree/src/lib.rs
@@ -80,7 +80,8 @@ pub struct FdtReader<'a, D: Driver> {
 
 fn cursor_u32(drv: &impl Driver, cursor: &mut usize) -> Result<u32> {
     let mut data = [0; 4];
-    *cursor += drv.pread(&mut data, *cursor)?;
+    drv.pread_exact(&mut data, *cursor)?;
+    *cursor += 4;
     Ok(BigEndian::read_u32(&data))
 }
 
@@ -105,10 +106,7 @@ fn read_fdt_header(drv: &impl Driver) -> Result<FdtHeader> {
     const HEADER_SIZE: usize = 10 * 4;
 
     let mut data = [0; HEADER_SIZE];
-    let size = drv.pread(&mut data, 0)?;
-    if size != HEADER_SIZE {
-        return Err("not enough data to read device tree header");
-    }
+    drv.pread_exact(&mut data, 0)?;
     let mut cursor = 0;
     let mut read_u32 = || {
         cursor += 4;

--- a/src/lib/device_tree/tests/integration_test.rs
+++ b/src/lib/device_tree/tests/integration_test.rs
@@ -162,5 +162,5 @@ fn test_returns_error_when_header_is_too_short() {
 };"#,
     );
     let slice_reader = &SliceReader::new(&data[0..4]);
-    assert_eq!(FdtReader::new(slice_reader).err(), Some("not enough data to read device tree header"));
+    assert_eq!(FdtReader::new(slice_reader).err(), Some("EOF"));
 }


### PR DESCRIPTION
This is similar to std::io::Read::read_exact, that reads the exact
number of bytes to fill in the input buffers. The current code often
assumes that the buffer will be fully filled in (especially when reading
u32 into a 4 byte buffer), this method will make it much easier to write
it correctly.