### PR TITLE
Lock version of heapless dependency.

### DIFF
--- a/src/drivers/uart/Cargo.toml
+++ b/src/drivers/uart/Cargo.toml
@@ -11,10 +11,8 @@ opt-level = 'z'  # Optimize for size.
 model = { path = "../model"}
 clock = { path = "../clock"}
 register = "0.3.2"
-
 # Heapless does not build for rv32imc.
-[dependencies.heapless]
-optional = true
+heapless = { version = "0.4.4", optional = true }
 
 [features]
 i8250 = ["heapless"]

--- a/src/mainboard/emulation/qemu-q35/Cargo.lock
+++ b/src/mainboard/emulation/qemu-q35/Cargo.lock
@@ -238,6 +238,7 @@ name = "uart"
 version = "0.1.0"
 dependencies = [
  "clock",
+ "heapless 0.5.4",
  "model",
  "register",
 ]


### PR DESCRIPTION
Running `make clippy` shows that src/drivers/uart does not specify the
exact version to use and that it will become an error in future
versions. To avoid a future breakage, just lock the version now.

Signed-off-by: Tomasz Zurkowski <zurkowski@google.com>