### PR TITLE
Use generics for print crate.

### DIFF
--- a/payloads/Cargo.lock
+++ b/payloads/Cargo.lock
@@ -60,7 +60,6 @@ version = "0.1.0"
 dependencies = [
  "model 0.1.0",
  "postcard 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "print 0.1.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "wrappers 0.1.0",
 ]
@@ -80,13 +79,6 @@ dependencies = [
 name = "postcard-cobs"
 version = "0.1.5-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "print"
-version = "0.1.0"
-dependencies = [
- "model 0.1.0",
-]
 
 [[package]]
 name = "proc-macro2"

--- a/payloads/Cargo.toml
+++ b/payloads/Cargo.toml
@@ -9,7 +9,6 @@ model = { path = "../src/drivers/model"}
 postcard = "0.4.3"
 serde = { version = "1.0", default-features = false }
 wrappers = { path = "../src/drivers/wrappers"}
-print = { path = "../src/lib/print" }
 
 [profile.release]
 opt-level = 'z'  # Optimize for size.

--- a/payloads/src/payload.rs
+++ b/payloads/src/payload.rs
@@ -1,4 +1,3 @@
-use core::fmt::Write;
 use core::intrinsics::{copy, transmute};
 use model::{Driver, EOF};
 use postcard::from_bytes;
@@ -186,7 +185,7 @@ pub struct CBFSSeg {
 // TOOD: remove all uses of non-streaming payloads.
 impl StreamPayload {
     /// Load the payload in memory. Returns the entrypoint.
-    pub fn load(&mut self, w: &mut print::WriteTo) {
+    pub fn load(&mut self, w: &mut impl core::fmt::Write) {
         // TODO: how many segments are there?
         // The coreboot convention: ENTRY marks the last segment.
         // we need to ensure we create them that way too.
@@ -254,7 +253,7 @@ impl StreamPayload {
     }
 
     /// Run the payload. This might not return.
-    pub fn run(&self, w: &mut print::WriteTo) {
+    pub fn run(&self, w: &mut impl core::fmt::Write) {
         // Jump to the payload.
         // See: linux/Documentation/arm/Booting
         unsafe {

--- a/src/arch/x86/x86_64/Cargo.lock
+++ b/src/arch/x86/x86_64/Cargo.lock
@@ -5,20 +5,12 @@ name = "arch"
 version = "0.1.0"
 dependencies = [
  "model",
- "print",
  "wrappers",
 ]
 
 [[package]]
 name = "model"
 version = "0.1.0"
-
-[[package]]
-name = "print"
-version = "0.1.0"
-dependencies = [
- "model",
-]
 
 [[package]]
 name = "wrappers"

--- a/src/arch/x86/x86_64/Cargo.toml
+++ b/src/arch/x86/x86_64/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 model = { path = "../../../drivers/model" }
-print = { path = "../../../lib/print" }
 wrappers = { path = "../../../drivers/wrappers"}
 
 [profile.release]

--- a/src/arch/x86/x86_64/src/bzimage.rs
+++ b/src/arch/x86/x86_64/src/bzimage.rs
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
 use crate::PAGE_SIZE;
-use core::fmt::Write;
 use core::intrinsics::copy;
 use core::mem::{size_of, transmute};
 use model::{Driver, Result};
@@ -173,7 +172,7 @@ impl Default for BootParams {
 }
 
 impl BzImage {
-    pub fn load(&mut self, w: &mut print::WriteTo) -> Result<usize> {
+    pub fn load(&mut self, w: &mut impl core::fmt::Write) -> Result<usize> {
         // The raw pointer shit is too painful.
         let rom = SectionReader::new(&Memory {}, self.rom_base, self.rom_size);
         let mut header: SetupHeader = {
@@ -271,7 +270,7 @@ impl BzImage {
     }
 
     /// Run the payload. This might not return.
-    pub fn run(&self, w: &mut print::WriteTo) {
+    pub fn run(&self, w: &mut impl core::fmt::Write) {
         // Jump to the payload.
         // See: linux/Documentation/arm/Booting
         unsafe {

--- a/src/lib/device_tree/Cargo.lock
+++ b/src/lib/device_tree/Cargo.lock
@@ -18,7 +18,6 @@ dependencies = [
  "model 0.1.0",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "print 0.1.0",
  "wrappers 0.1.0",
 ]
 
@@ -42,13 +41,6 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "print"
-version = "0.1.0"
-dependencies = [
- "model 0.1.0",
 ]
 
 [[package]]

--- a/src/lib/device_tree/Cargo.toml
+++ b/src/lib/device_tree/Cargo.toml
@@ -9,7 +9,6 @@ byteorder = { version = "1", default-features = false }
 model = { path = "../../drivers/model"}
 num-derive = { version = "0.2", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-print = { path = "../../lib/print" }
 wrappers = { path = "../../drivers/wrappers"}
 
 [profile.release]

--- a/src/lib/device_tree/src/lib.rs
+++ b/src/lib/device_tree/src/lib.rs
@@ -23,7 +23,6 @@ extern crate num_derive;
 
 use byteorder::{BigEndian, ByteOrder};
 use core::fmt;
-use core::fmt::Write;
 use model::{Driver, Result};
 use wrappers::SectionReader;
 
@@ -212,7 +211,7 @@ impl<'a, D: Driver> FdtIterator<'a, D> {
 
 /// Reads the device tree in FDT format from given driver and writes it in human readable form to
 /// given writer.
-pub fn print_fdt(fdt: &mut impl Driver, w: &mut print::WriteTo) -> Result<()> {
+pub fn print_fdt(fdt: &mut impl Driver, w: &mut impl core::fmt::Write) -> Result<()> {
     let reader = FdtReader::new(fdt)?;
     let mut iter = reader.walk();
     let mut depth = 0;

--- a/src/lib/print/src/lib.rs
+++ b/src/lib/print/src/lib.rs
@@ -3,17 +3,17 @@
 use core::fmt;
 use model::Driver;
 
-pub struct WriteTo<'a> {
-    drv: &'a mut dyn Driver,
+pub struct WriteTo<'a, D: Driver> {
+    drv: &'a mut D,
 }
 
-impl<'a> WriteTo<'a> {
-    pub fn new(drv: &'a mut dyn Driver) -> Self {
+impl<'a, D: Driver> WriteTo<'a, D> {
+    pub fn new(drv: &'a mut D) -> Self {
         WriteTo { drv }
     }
 }
 
-impl<'a> fmt::Write for WriteTo<'a> {
+impl<'a, D: Driver> fmt::Write for WriteTo<'a, D> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         match self.drv.pwrite(s.as_bytes(), 0) {
             Err(_) => Err(fmt::Error),

--- a/src/mainboard/amd/romecrb/Cargo.lock
+++ b/src/mainboard/amd/romecrb/Cargo.lock
@@ -5,7 +5,6 @@ name = "arch"
 version = "0.1.0"
 dependencies = [
  "model",
- "print",
  "wrappers",
 ]
 
@@ -104,7 +103,6 @@ version = "0.1.0"
 dependencies = [
  "model",
  "postcard",
- "print",
  "serde",
  "wrappers",
 ]

--- a/src/mainboard/emulation/qemu-q35/Cargo.lock
+++ b/src/mainboard/emulation/qemu-q35/Cargo.lock
@@ -5,7 +5,6 @@ name = "arch"
 version = "0.1.0"
 dependencies = [
  "model",
- "print",
  "wrappers",
 ]
 
@@ -104,7 +103,6 @@ version = "0.1.0"
 dependencies = [
  "model",
  "postcard",
- "print",
  "serde",
  "wrappers",
 ]

--- a/src/mainboard/emulation/qemu-riscv/Cargo.lock
+++ b/src/mainboard/emulation/qemu-riscv/Cargo.lock
@@ -8,15 +8,17 @@ version = "0.1.0"
 name = "as-slice"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293dac66b274fab06f95e7efb05ec439a6b70136081ea522d270bc351ae5bb27"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "clock"
@@ -30,53 +32,59 @@ version = "0.1.0"
 name = "generic-array"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8107dafa78c80c848b71b60133954b4a58609a3a1a5f9af037ecc7f67280f369"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "hash32"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
 ]
 
 [[package]]
 name = "heapless"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ae80bbc62401ae8096976857172507cadbd2200f36670e5144634360a05959"
 dependencies = [
- "as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "as-slice",
+ "generic-array 0.11.1",
+ "hash32",
 ]
 
 [[package]]
 name = "heapless"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b591a0032f114b7a77d4fbfab452660c553055515b7d7ece355db080d19087"
 dependencies = [
- "as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "as-slice",
+ "generic-array 0.13.2",
+ "hash32",
+ "serde",
 ]
 
 [[package]]
@@ -87,185 +95,174 @@ version = "0.1.0"
 name = "payloads"
 version = "0.1.0"
 dependencies = [
- "model 0.1.0",
- "postcard 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "print 0.1.0",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "wrappers 0.1.0",
+ "model",
+ "postcard",
+ "serde",
+ "wrappers",
 ]
 
 [[package]]
 name = "postcard"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61f42c9617f3d7b447ee300bf80cb16c7cd7b28ca88555822793f073f69719f"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapless 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "postcard-cobs 0.1.5-pre (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "heapless 0.5.3",
+ "postcard-cobs",
+ "serde",
 ]
 
 [[package]]
 name = "postcard-cobs"
 version = "0.1.5-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
 
 [[package]]
 name = "print"
 version = "0.1.0"
 dependencies = [
- "model 0.1.0",
+ "model",
 ]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "qemu-riscv"
 version = "0.1.0"
 dependencies = [
- "arch 0.1.0",
- "console 0.1.0",
- "heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "model 0.1.0",
- "payloads 0.1.0",
- "print 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "soc 0.1.0",
- "static-ref 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uart 0.1.0",
- "wrappers 0.1.0",
+ "arch",
+ "console",
+ "heapless 0.4.4",
+ "model",
+ "payloads",
+ "print",
+ "register",
+ "soc",
+ "static-ref",
+ "uart",
+ "wrappers",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "register"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469bb5ddde81d67fb8bba4e14d77689b8166cfd077abe7530591cefe29d05823"
 dependencies = [
- "tock-registers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tock-registers",
 ]
 
 [[package]]
 name = "serde"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 dependencies = [
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "soc"
 version = "0.1.0"
 dependencies = [
- "arch 0.1.0",
- "clock 0.1.0",
- "model 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "spi 0.1.0",
+ "arch",
+ "clock",
+ "model",
+ "register",
+ "spi",
 ]
 
 [[package]]
 name = "spi"
 version = "0.1.0"
 dependencies = [
- "clock 0.1.0",
- "model 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock",
+ "model",
+ "register",
 ]
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "static-ref"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c13349fd3abcbb70dd954f300f5c0c27b71a94f4697adc301501de2c6934d0"
 
 [[package]]
 name = "syn"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "tock-registers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c758f5195a2e0df9d9fecf6f506506b2766ff74cf64db1e995c87e2761a5c3e2"
 
 [[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 
 [[package]]
 name = "uart"
 version = "0.1.0"
 dependencies = [
- "clock 0.1.0",
- "model 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock",
+ "model",
+ "register",
 ]
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "wrappers"
 version = "0.1.0"
 dependencies = [
- "model 0.1.0",
+ "model",
 ]
-
-[metadata]
-"checksum as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "293dac66b274fab06f95e7efb05ec439a6b70136081ea522d270bc351ae5bb27"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8107dafa78c80c848b71b60133954b4a58609a3a1a5f9af037ecc7f67280f369"
-"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
-"checksum hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
-"checksum heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ae80bbc62401ae8096976857172507cadbd2200f36670e5144634360a05959"
-"checksum heapless 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10b591a0032f114b7a77d4fbfab452660c553055515b7d7ece355db080d19087"
-"checksum postcard 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f61f42c9617f3d7b447ee300bf80cb16c7cd7b28ca88555822793f073f69719f"
-"checksum postcard-cobs 0.1.5-pre (registry+https://github.com/rust-lang/crates.io-index)" = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
-"checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
-"checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
-"checksum register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "469bb5ddde81d67fb8bba4e14d77689b8166cfd077abe7530591cefe29d05823"
-"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
-"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum static-ref 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c13349fd3abcbb70dd954f300f5c0c27b71a94f4697adc301501de2c6934d0"
-"checksum syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
-"checksum tock-registers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c758f5195a2e0df9d9fecf6f506506b2766ff74cf64db1e995c87e2761a5c3e2"
-"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/src/mainboard/opentitan/crb/Cargo.lock
+++ b/src/mainboard/opentitan/crb/Cargo.lock
@@ -8,16 +8,18 @@ version = "0.1.0"
 name = "as-slice"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37dfb65bc03b2bc85ee827004f14a6817e04160e3b1a28931986a666a9290e70"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3",
+ "generic-array 0.13.2",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "clock"
@@ -31,58 +33,62 @@ version = "0.1.0"
 name = "cpu"
 version = "0.1.0"
 dependencies = [
- "arch 0.1.0",
+ "arch",
 ]
 
 [[package]]
 name = "crb"
 version = "0.1.0"
 dependencies = [
- "console 0.1.0",
- "model 0.1.0",
- "payloads 0.1.0",
- "print 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "soc 0.1.0",
- "static-ref 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uart 0.1.0",
- "wrappers 0.1.0",
+ "console",
+ "model",
+ "payloads",
+ "print",
+ "register",
+ "soc",
+ "static-ref",
+ "uart",
+ "wrappers",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
- "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 dependencies = [
- "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "hash32"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
 ]
 
 [[package]]
 name = "heapless"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffa511365b12346c5fbe759d82f80d3aa70d9f1ba01955594f84a1a6bbab985"
 dependencies = [
- "as-slice 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash32 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "as-slice",
+ "generic-array 0.13.2",
+ "hash32",
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -93,156 +99,147 @@ version = "0.1.0"
 name = "payloads"
 version = "0.1.0"
 dependencies = [
- "model 0.1.0",
- "postcard 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "print 0.1.0",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "wrappers 0.1.0",
+ "model",
+ "postcard",
+ "serde",
+ "wrappers",
 ]
 
 [[package]]
 name = "postcard"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61f42c9617f3d7b447ee300bf80cb16c7cd7b28ca88555822793f073f69719f"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapless 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "postcard-cobs 0.1.5-pre (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "heapless",
+ "postcard-cobs",
+ "serde",
 ]
 
 [[package]]
 name = "postcard-cobs"
 version = "0.1.5-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
 
 [[package]]
 name = "print"
 version = "0.1.0"
 dependencies = [
- "model 0.1.0",
+ "model",
 ]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "register"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469bb5ddde81d67fb8bba4e14d77689b8166cfd077abe7530591cefe29d05823"
 dependencies = [
- "tock-registers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tock-registers",
 ]
 
 [[package]]
 name = "serde"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 dependencies = [
- "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "soc"
 version = "0.1.0"
 dependencies = [
- "clock 0.1.0",
- "cpu 0.1.0",
- "model 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock",
+ "cpu",
+ "model",
+ "register",
 ]
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "static-ref"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c13349fd3abcbb70dd954f300f5c0c27b71a94f4697adc301501de2c6934d0"
 
 [[package]]
 name = "syn"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "tock-registers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c758f5195a2e0df9d9fecf6f506506b2766ff74cf64db1e995c87e2761a5c3e2"
 
 [[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uart"
 version = "0.1.0"
 dependencies = [
- "clock 0.1.0",
- "model 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock",
+ "model",
+ "register",
 ]
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "wrappers"
 version = "0.1.0"
 dependencies = [
- "model 0.1.0",
+ "model",
 ]
-
-[metadata]
-"checksum as-slice 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "37dfb65bc03b2bc85ee827004f14a6817e04160e3b1a28931986a666a9290e70"
-"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
-"checksum hash32 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
-"checksum heapless 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ffa511365b12346c5fbe759d82f80d3aa70d9f1ba01955594f84a1a6bbab985"
-"checksum postcard 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f61f42c9617f3d7b447ee300bf80cb16c7cd7b28ca88555822793f073f69719f"
-"checksum postcard-cobs 0.1.5-pre (registry+https://github.com/rust-lang/crates.io-index)" = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
-"checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
-"checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
-"checksum register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "469bb5ddde81d67fb8bba4e14d77689b8166cfd077abe7530591cefe29d05823"
-"checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
-"checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
-"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum static-ref 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c13349fd3abcbb70dd954f300f5c0c27b71a94f4697adc301501de2c6934d0"
-"checksum syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
-"checksum tock-registers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c758f5195a2e0df9d9fecf6f506506b2766ff74cf64db1e995c87e2761a5c3e2"
-"checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/src/mainboard/sifive/hifive/Cargo.lock
+++ b/src/mainboard/sifive/hifive/Cargo.lock
@@ -8,20 +8,23 @@ version = "0.1.0"
 name = "as-slice"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293dac66b274fab06f95e7efb05ec439a6b70136081ea522d270bc351ae5bb27"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "autocfg"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 
 [[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "clock"
@@ -35,85 +38,90 @@ version = "0.1.0"
 name = "device_tree"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "model 0.1.0",
- "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "print 0.1.0",
- "wrappers 0.1.0",
+ "byteorder",
+ "model",
+ "num-derive",
+ "num-traits",
+ "wrappers",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8107dafa78c80c848b71b60133954b4a58609a3a1a5f9af037ecc7f67280f369"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "hash32"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
 ]
 
 [[package]]
 name = "heapless"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ae80bbc62401ae8096976857172507cadbd2200f36670e5144634360a05959"
 dependencies = [
- "as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "as-slice",
+ "generic-array 0.11.1",
+ "hash32",
 ]
 
 [[package]]
 name = "heapless"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b591a0032f114b7a77d4fbfab452660c553055515b7d7ece355db080d19087"
 dependencies = [
- "as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "as-slice",
+ "generic-array 0.13.2",
+ "hash32",
+ "serde",
 ]
 
 [[package]]
 name = "hifive"
 version = "0.1.0"
 dependencies = [
- "arch 0.1.0",
- "clock 0.1.0",
- "console 0.1.0",
- "device_tree 0.1.0",
- "heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "model 0.1.0",
- "payloads 0.1.0",
- "print 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "soc 0.1.0",
- "spi 0.1.0",
- "static-ref 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uart 0.1.0",
- "wrappers 0.1.0",
+ "arch",
+ "clock",
+ "console",
+ "device_tree",
+ "heapless 0.4.4",
+ "model",
+ "payloads",
+ "print",
+ "register",
+ "soc",
+ "spi",
+ "static-ref",
+ "uart",
+ "wrappers",
 ]
 
 [[package]]
@@ -124,225 +132,213 @@ version = "0.1.0"
 name = "num-derive"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
 ]
 
 [[package]]
 name = "payloads"
 version = "0.1.0"
 dependencies = [
- "model 0.1.0",
- "postcard 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "print 0.1.0",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "wrappers 0.1.0",
+ "model",
+ "postcard",
+ "serde",
+ "wrappers",
 ]
 
 [[package]]
 name = "postcard"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61f42c9617f3d7b447ee300bf80cb16c7cd7b28ca88555822793f073f69719f"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapless 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "postcard-cobs 0.1.5-pre (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "heapless 0.5.3",
+ "postcard-cobs",
+ "serde",
 ]
 
 [[package]]
 name = "postcard-cobs"
 version = "0.1.5-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
 
 [[package]]
 name = "print"
 version = "0.1.0"
 dependencies = [
- "model 0.1.0",
+ "model",
 ]
 
 [[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9",
 ]
 
 [[package]]
 name = "register"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469bb5ddde81d67fb8bba4e14d77689b8166cfd077abe7530591cefe29d05823"
 dependencies = [
- "tock-registers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tock-registers",
 ]
 
 [[package]]
 name = "serde"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 dependencies = [
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9",
+ "quote 1.0.2",
+ "syn 1.0.16",
 ]
 
 [[package]]
 name = "soc"
 version = "0.1.0"
 dependencies = [
- "arch 0.1.0",
- "clock 0.1.0",
- "model 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "spi 0.1.0",
+ "arch",
+ "clock",
+ "model",
+ "register",
+ "spi",
 ]
 
 [[package]]
 name = "spi"
 version = "0.1.0"
 dependencies = [
- "clock 0.1.0",
- "model 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock",
+ "model",
+ "register",
 ]
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "static-ref"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c13349fd3abcbb70dd954f300f5c0c27b71a94f4697adc301501de2c6934d0"
 
 [[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
 name = "syn"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9",
+ "quote 1.0.2",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "tock-registers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c758f5195a2e0df9d9fecf6f506506b2766ff74cf64db1e995c87e2761a5c3e2"
 
 [[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 
 [[package]]
 name = "uart"
 version = "0.1.0"
 dependencies = [
- "clock 0.1.0",
- "heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "model 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock",
+ "heapless 0.4.4",
+ "model",
+ "register",
 ]
 
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "wrappers"
 version = "0.1.0"
 dependencies = [
- "model 0.1.0",
+ "model",
 ]
-
-[metadata]
-"checksum as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "293dac66b274fab06f95e7efb05ec439a6b70136081ea522d270bc351ae5bb27"
-"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8107dafa78c80c848b71b60133954b4a58609a3a1a5f9af037ecc7f67280f369"
-"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
-"checksum hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
-"checksum heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ae80bbc62401ae8096976857172507cadbd2200f36670e5144634360a05959"
-"checksum heapless 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10b591a0032f114b7a77d4fbfab452660c553055515b7d7ece355db080d19087"
-"checksum num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
-"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum postcard 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f61f42c9617f3d7b447ee300bf80cb16c7cd7b28ca88555822793f073f69719f"
-"checksum postcard-cobs 0.1.5-pre (registry+https://github.com/rust-lang/crates.io-index)" = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "469bb5ddde81d67fb8bba4e14d77689b8166cfd077abe7530591cefe29d05823"
-"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
-"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum static-ref 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c13349fd3abcbb70dd954f300f5c0c27b71a94f4697adc301501de2c6934d0"
-"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
-"checksum tock-registers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c758f5195a2e0df9d9fecf6f506506b2766ff74cf64db1e995c87e2761a5c3e2"
-"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/src/mainboard/sifive/hifive/src/main.rs
+++ b/src/mainboard/sifive/hifive/src/main.rs
@@ -156,7 +156,7 @@ pub extern "C" fn _start_boot_hart(_hart_id: usize, fdt_address: usize) -> ! {
 }
 
 // Returns Err((address, got)) or OK(()).
-fn test_ddr(addr: *mut u32, size: usize, w: &mut print::WriteTo) -> Result<(), (*const u32, u32)> {
+fn test_ddr(addr: *mut u32, size: usize, w: &mut impl core::fmt::Write) -> Result<(), (*const u32, u32)> {
     write!(w, "Starting to fill with data\r\n").unwrap();
     // Fill with data.
     for i in 0..(size / 4) {

--- a/tools/layoutflash/Cargo.lock
+++ b/tools/layoutflash/Cargo.lock
@@ -70,7 +70,6 @@ dependencies = [
  "model 0.1.0",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "print 0.1.0",
  "wrappers 0.1.0",
 ]
 
@@ -138,13 +137,6 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "print"
-version = "0.1.0"
-dependencies = [
- "model 0.1.0",
 ]
 
 [[package]]


### PR DESCRIPTION
This change uses generics inside print::WriteTo type as well as in all
places that used this type.

Ref: #38

Signed-off-by: Tomasz Zurkowski <zurkowski@google.com>