### PR TITLE
Update rust toolchain version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ help:
 
 BROKEN := \
 	src/mainboard/ast/ast25x0/Makefile \
-	src/mainboard/nuvoton/npcm7xx/Makefile \
 	src/mainboard/emulation/qemu-armv7/Makefile \
 
 MAINBOARDS := $(filter-out $(BROKEN), $(wildcard src/mainboard/*/*/Makefile))

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ BROKEN := \
 
 MAINBOARDS := $(filter-out $(BROKEN), $(wildcard src/mainboard/*/*/Makefile))
 
-TOOLCHAIN_VER := nightly-2020-04-22
-XBUILD_VER := 0.5.29
-BINUTILS_VER := 0.2.0
+TOOLCHAIN_VER := nightly-2020-10-25
+XBUILD_VER := 0.6.3
+BINUTILS_VER := 0.3.2
 
 .PHONY: mainboards $(MAINBOARDS)
 mainboards: $(MAINBOARDS)


### PR DESCRIPTION
There are some mainboards (ref #283) that fail to compile because version of compiler_builtins is not locked. The simplest fix is to just update the toolchain to a newer one.