### PR TITLE
Run clippy on sifive/hifive mainboard.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,28 @@ $(CRATES_TO_TEST):
 .PHONY: test $(CRATES_TO_TEST)
 test: $(CRATES_TO_TEST)
 
-CRATES_TO_CLIPPY := $(patsubst %/Cargo.toml,%/Cargo.toml.clippy,$(filter-out $(BROKEN_CRATES_TO_TEST),$(CRATES)))
+BROKEN_CRATES_TO_CLIPPY := \
+	src/arch/arm/armv7/Cargo.toml \
+	src/arch/riscv/rv32/Cargo.toml \
+	src/arch/riscv/rv64/Cargo.toml \
+	src/cpu/armltd/cortex-a9/Cargo.toml \
+	src/cpu/lowrisc/ibex/Cargo.toml \
+	src/mainboard/amd/romecrb/Cargo.toml \
+	src/mainboard/ast/ast25x0/Cargo.toml \
+	src/mainboard/emulation/qemu-armv7/Cargo.toml \
+	src/mainboard/emulation/qemu-q35/Cargo.toml \
+	src/mainboard/emulation/qemu-riscv/Cargo.toml \
+	src/mainboard/nuvoton/npcm7xx/Cargo.toml \
+	src/mainboard/opentitan/crb/Cargo.toml \
+	src/soc/aspeed/ast2500/Cargo.toml \
+	src/soc/opentitan/earlgrey/Cargo.toml \
+	src/soc/sifive/fu540/Cargo.toml \
+	src/vendorcode/fsp/coffeelake/Cargo.toml \
+
+# TODO: Remove write_with_newline
+CRATES_TO_CLIPPY := $(patsubst %/Cargo.toml,%/Cargo.toml.clippy,$(filter-out $(BROKEN_CRATES_TO_CLIPPY),$(CRATES)))
 $(CRATES_TO_CLIPPY):
-	cd $(dir $@) && cargo clippy -- -D warnings
+	cd $(dir $@) && cargo clippy -- -D warnings -A clippy::write_with_newline
 .PHONY: clippy $(CRATES_TO_CLIPPY)
 clippy: $(CRATES_TO_CLIPPY)
 

--- a/src/drivers/uart/src/log.rs
+++ b/src/drivers/uart/src/log.rs
@@ -36,7 +36,7 @@ impl<'a> Driver for Log<'a> {
     }
 
     fn pread(&self, _data: &mut [u8], _offset: usize) -> Result<usize> {
-        return Ok(0);
+        Ok(0)
     }
 
     fn pwrite(&mut self, data: &[u8], _offset: usize) -> Result<usize> {

--- a/src/drivers/uart/src/sifive.rs
+++ b/src/drivers/uart/src/sifive.rs
@@ -87,7 +87,7 @@ register_bitfields! {
 
 impl SiFive {
     pub fn new(base: usize, baudrate: u32) -> SiFive {
-        SiFive { base: base, baudrate: baudrate }
+        SiFive { base, baudrate }
     }
 
     /// Returns a pointer to the register block

--- a/src/mainboard/sifive/hifive/src/main.rs
+++ b/src/mainboard/sifive/hifive/src/main.rs
@@ -13,7 +13,6 @@ use core::{fmt::Write, ptr};
 use device_tree::print_fdt;
 use model::Driver;
 use payloads::payload;
-use print;
 use soc::clock::Clock;
 use soc::ddr::DDR;
 use soc::is_qemu;

--- a/src/soc/sifive/fu540/src/clock.rs
+++ b/src/soc/sifive/fu540/src/clock.rs
@@ -216,7 +216,7 @@ impl<'a> Driver for Clock<'a> {
 
 impl<'a> Clock<'a> {
     pub fn new(clks: &'a mut [&'a mut dyn ClockNode]) -> Clock<'a> {
-        Clock::<'a> { base: reg::PRCI as usize, clks: clks }
+        Clock::<'a> { base: reg::PRCI as usize, clks }
     }
 
     /// Returns a pointer to the register block

--- a/src/soc/sifive/fu540/src/ddr.rs
+++ b/src/soc/sifive/fu540/src/ddr.rs
@@ -57,6 +57,12 @@ impl DDR {
     }
 }
 
+impl Default for DDR {
+    fn default() -> Self {
+        DDR::new()
+    }
+}
+
 impl Driver for DDR {
     fn init(&mut self) -> Result<()> {
         /* nothing to do. */
@@ -252,7 +258,7 @@ fn sdram_init() {
 
 pub fn mem_size() -> u64 {
     if is_qemu() {
-        return 1 * 1024 * 1024 * 1024;
+        return 1024 * 1024 * 1024;
     }
     reg::DDR_SIZE
 }

--- a/src/soc/sifive/fu540/src/ux00.rs
+++ b/src/soc/sifive/fu540/src/ux00.rs
@@ -37,14 +37,14 @@ pub const PHY_RX_CAL_DQ1_0_OFFSET: u64 = 16;
 // This is a 64-bit machine but all this action seems to be on 32-bit values.
 // No idea why this is.
 // index is a word offset.
-fn poke(pointer: u32, index: u32, value: u32) -> () {
+fn poke(pointer: u32, index: u32, value: u32) {
     let addr = (pointer + (index << 2)) as *mut u32;
     unsafe {
         ptr::write_volatile(addr, value);
     }
 }
 
-fn poke64(pointer: u32, index: u32, value: u64) -> () {
+fn poke64(pointer: u32, index: u32, value: u64) {
     let addr = (pointer + (index << 2)) as *mut u64;
     //let addr1 = (pointer + (index << 2) + 4) as *mut u32;
     unsafe {
@@ -56,12 +56,12 @@ fn poke64(pointer: u32, index: u32, value: u64) -> () {
     }
 }
 
-fn set(pointer: u32, index: u32, value: u32) -> () {
+fn set(pointer: u32, index: u32, value: u32) {
     let v = peek(pointer, index);
     poke(pointer, index, v | value);
 }
 
-fn clr(pointer: u32, index: u32, value: u32) -> () {
+fn clr(pointer: u32, index: u32, value: u32) {
     let v = peek(pointer, index);
     poke(pointer, index, v & value);
 }
@@ -196,7 +196,7 @@ pub fn ux00ddr_phy_fixup() -> u64 {
 
     //let mut fails: u64 = 0;
     let mut slicebase: u32 = 0;
-    let mut dq: u32 = 0;
+    //let mut dq: u32 = 0;
     for _ in 0..8 {
         // check errata condition
         let regbase: u32 = slicebase + 34;
@@ -226,7 +226,7 @@ pub fn ux00ddr_phy_fixup() -> u64 {
                     //else uart_puts((void*) UART0_CTRL_ADDR, "D");
                     //uart_puts((void*) UART0_CTRL_ADDR, "\n");
                 }
-                dq = dq + 1;
+                //dq += 1;
             }
         }
         slicebase += 128;


### PR DESCRIPTION
This change creates a separate list for BROKEN crates that do not work
with clippy yet (previuosly we shared the list for `cargo test`). It
also removes sifive/hifive mainboard from broken list and fixes all
existing errors.

Signed-off-by: Tomasz Zurkowski <zurkowski@google.com>