### PR TITLE
Allow running crates clippy using host target.

### DIFF
--- a/src/drivers/uart/src/i8250.rs
+++ b/src/drivers/uart/src/i8250.rs
@@ -22,7 +22,7 @@ impl<'a> I8250<'a> {
                 return true;
             }
         }
-        return false;
+        false
     }
 }
 #[allow(dead_code)]

--- a/src/mainboard/emulation/qemu-armv7/src/main.rs
+++ b/src/mainboard/emulation/qemu-armv7/src/main.rs
@@ -11,7 +11,6 @@ use core::fmt::Write;
 use device_tree::print_fdt;
 use model::Driver;
 use payloads::external::zimage::DTB;
-use uart;
 use wrappers::{DoD, SliceReader};
 
 #[no_mangle]
@@ -40,7 +39,7 @@ pub extern "C" fn _start() -> ! {
     write!(w, "5").expect("blame ryan");
     write!(w, "6").expect("blame ryan");
     write!(w, "7").expect("blame ryan");
-    write!(w, "{}{}\r\n", 3, "7").expect("blame ryan");
+    write!(w, "{}{}\r\n", 3, 7).expect("blame ryan");
     romstage::romstage()
 }
 use core::panic::PanicInfo;

--- a/src/mainboard/emulation/qemu-q35/src/main.rs
+++ b/src/mainboard/emulation/qemu-q35/src/main.rs
@@ -9,19 +9,18 @@ use arch::ioport::IOPort;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use model::Driver;
-use print;
 use uart::debug_port::DebugPort;
 use uart::i8250::I8250;
 
 global_asm!(include_str!("../../../../arch/x86/x86_64/src/bootblock.S"));
 
 #[no_mangle]
-pub extern "C" fn _start(fdt_address: usize) -> ! {
+pub extern "C" fn _start(_fdt_address: usize) -> ! {
     let io = &mut IOPort;
     let uart0 = &mut I8250::new(0x3f8, 0, io);
     // Note: on real hardware, use port 0x80 instead for "POST" output
-    let debugIO = &mut IOPort;
-    let debug = &mut DebugPort::new(0xe9, debugIO);
+    let debug_io = &mut IOPort;
+    let debug = &mut DebugPort::new(0xe9, debug_io);
     uart0.init().unwrap();
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
     debug.init().unwrap();


### PR DESCRIPTION
This will allow us to fix clippy errors on all mainboards (we need #322
to fix more mainboards).