### PR TITLE
asrock/a300m-stx: fix arg parsing in patch.go

### DIFF
--- a/src/mainboard/asrock/a300m-stx/patch.go
+++ b/src/mainboard/asrock/a300m-stx/patch.go
@@ -18,6 +18,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	flag.Parse()
 	a := flag.Args()
 	if len(a) == 0 {
 		a = append(a, "serial.bin@FFFFF0")


### PR DESCRIPTION
Signed-off-by: Daniel Maslowski <info@orangecms.org>