### PR TITLE
mainboard/opentitan: Get oreboot booting in QEMU

### DIFF
--- a/src/mainboard/opentitan/crb/link.ld
+++ b/src/mainboard/opentitan/crb/link.ld
@@ -30,6 +30,10 @@ SECTIONS
     . = 0x20000000;
     .bootblock :
     {
+        /* Ensure that the flash header matches what the OpenTitain ROM expects.
+         */
+        LONG(_stext);
+        _stext = .;
         KEEP(*(.bootblock.boot));
     }
     .text :


### PR DESCRIPTION
With this patch oreboot now boots after the OpenTitan boot ROM in QEMU.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>