### PR TITLE
Enable 'make run' for qemu-armv7 mainboard

### DIFF
--- a/src/mainboard/emulation/qemu-armv7/Makefile
+++ b/src/mainboard/emulation/qemu-armv7/Makefile
@@ -1,2 +1,5 @@
 TARGET     = arm-none-eabihf
+QEMU       = qemu-system-arm
+QEMU_FLAGS = -machine virt -nographic -m 2g -bios $(IMAGE)
 include ../../../../Makefile.inc
+include ../../../../Makefile.qemu.inc


### PR DESCRIPTION
qemu-arvm7 is currently missing 'make run', add it.