### PR TITLE
Remove fsp-coffeelake from broken crate list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,6 @@ BROKEN_CRATES_TO_TEST := \
 	src/soc/aspeed/ast2500/Cargo.toml \
 	src/soc/opentitan/earlgrey/Cargo.toml \
 	src/soc/sifive/fu540/Cargo.toml \
-	src/vendorcode/fsp/coffeelake/Cargo.toml \
 
 CRATES_TO_TEST := $(patsubst %/Cargo.toml,%/Cargo.toml.test,$(filter-out $(BROKEN_CRATES_TO_TEST),$(CRATES)))
 $(CRATES_TO_TEST):

--- a/src/vendorcode/fsp/coffeelake/Cargo.lock
+++ b/src/vendorcode/fsp/coffeelake/Cargo.lock
@@ -115,11 +115,12 @@ dependencies = [
 [[package]]
 name = "efi"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da7e44d352c716b8b7ad9ca0a76683ec8be5e8834ad86720df0666b29151089"
+source = "git+https://github.com/rjoleary/efi#5c169fc6fd9c402c5f7083c8461874bc8c4d755e"
 dependencies = [
  "byteorder",
  "failure",
+ "rlibc",
+ "utf8-width",
 ]
 
 [[package]]
@@ -290,6 +291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
+name = "rlibc"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +375,12 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
 
 [[package]]
 name = "vec_map"

--- a/src/vendorcode/fsp/coffeelake/Cargo.toml
+++ b/src/vendorcode/fsp/coffeelake/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Oreboot Authors"]
 edition = "2018"
 
 [dependencies]
-efi = "0.2.1"
+# TODO: Revert to `efi = "0.x.y"` once changes are merged upstream and published.
+efi = { git = "https://github.com/rjoleary/efi" }
 
 [build-dependencies]
 bindgen = "0.53.1"


### PR DESCRIPTION
Remove fsp-coffeelake from broken crate list

This contains two fixes:

1. nightly-2020-10-30 broke the efi crate. This changes includes the
   following fix:

       https://github.com/gurry/efi/commit/b639a367ddc794f0ab90e1d3278956b6bd23dd5e

2. The efi crate defines a global allocator which breaks everything.
   This change includes the following fix which is pending a merge
   upstream:

       https://github.com/rjoleary/efi/commit/5c169fc6fd9c402c5f7083c8461874bc8c4d755e

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>