### PR TITLE
Squelch dtc warnings

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -36,15 +36,16 @@ $(info rustc --version  = $(shell rustc --version))
 $(info rustup --version = $(shell rustup --version))
 $(info **********)
 
-$(TARGET_DIR)/%.dtb: %.dts
-	dtc $< -O dtb -o $@
-
 $(IMAGE): $(BOOTBLOB) $(TARGET_DIR)/$(FIXED_DTFS)
 	TARGET_DIR=$(TARGET_DIR) cargo run --target $(TOOLS_TARGET) --manifest-path $(TOOLS_DIR)/layoutflash/Cargo.toml -- $(TARGET_DIR)/$(FIXED_DTFS) $@
 	@printf "**\n** Output: $@\n**\n"
 
 $(TARGET_DIR)/bootblob.bin: $(ELF)
 	$(OBJCOPY) -O binary -R .bss $< $@
+
+$(TARGET_DIR)/fixed-dtfs.dtb: fixed-dtfs.dts
+	mkdir -p $(TARGET_DIR)
+	dtc -W no-unit_address_vs_reg $< -O dtb -o $@
 
 # Re-run cargo every time.
 .PHONY: $(ELF)


### PR DESCRIPTION
Such of the following:

fixed-dtfs.dts:13.20-19.15: Warning (unit_address_vs_reg): /flash-info/areas/area@0: node has a unit name, but no reg property

The fixed-dtfs nodes do not have reg properties.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>