### PR TITLE
Replace 'cargo xbuild' by 'cargo build -Z build-std=core,alloc'

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -50,7 +50,8 @@ statically allocated size.
 
 The binary is generated in two steps:
 
-* Build ELF (Executable and Linkable Format) binary, with `cargo xbuild` command.
+* Build ELF (Executable and Linkable Format) binary, with
+`cargo build --target $(TARGET) -Z build-std=core,alloc` command.
 * Convert it to binary format with `rust-objcopy` into `bootblob.bin` file.
 
 This `bootblob.bin` is then used to construct the image that will be written

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ BROKEN := \
 MAINBOARDS := $(filter-out $(BROKEN), $(wildcard src/mainboard/*/*/Makefile))
 
 TOOLCHAIN_VER := nightly-2020-10-25
-XBUILD_VER := 0.6.3
 BINUTILS_VER := 0.3.2
 
 .PHONY: mainboards $(MAINBOARDS)
@@ -36,7 +35,6 @@ firsttime:
 	rustup target add riscv32imc-unknown-none-elf
 	rustup target add armv7r-none-eabi
 	rustup target add aarch64-unknown-none-softfloat
-	cargo install $(if $(XBUILD_VER),--version $(XBUILD_VER),) cargo-xbuild
 	cargo install $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
 
 firsttime_fsp:

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -48,7 +48,7 @@ $(TARGET_DIR)/bootblob.bin: $(ELF)
 # Re-run cargo every time.
 .PHONY: $(ELF)
 $(ELF):
-	RUST_TARGET_PATH=$(TOP)/src/custom_targets cargo xbuild $(CARGO_FLAGS)
+	RUST_TARGET_PATH=$(TOP)/src/custom_targets cargo build --target "$(TARGET)" -Z build-std=core,alloc $(CARGO_FLAGS)
 
 clean:
 	rm -rf target/


### PR DESCRIPTION
Most of the functionality of `cargo xbuild` has been integrated into `cargo build` anyway. Even `cargo xbuild` website strongly recommends using `cargo build`.
 
* Makefile.inc (ELF): Use 'cargo build -Z build-std=core,alloc' instead
of 'cargo xbuild'.
* Makefile: Don't install 'cargo xbuild'.
* Documentation/getting-started.md: Update.

Signed-off-by: Danny Milosavljevic <dannym@scratchpost.org>