### PR TITLE
Make OBJCOPY configurable.

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -6,6 +6,7 @@ MODE       ?= release
 FIXED_DTFS  = fixed-dtfs.dtb
 TOOLS_DIR   = $(TOP)/tools
 FLASHROM_PROGRAMMER ?= dediprog
+OBJCOPY    ?= rust-objcopy
 # Cargo will build the tools using the target from the .cargo directory which
 # does not work so well if you are cross-compiling. This shell one-liner gets
 # the target of the current system which can be passed via --target for
@@ -43,7 +44,7 @@ $(IMAGE): $(BOOTBLOB) $(TARGET_DIR)/$(FIXED_DTFS)
 	@printf "**\n** Output: $@\n**\n"
 
 $(TARGET_DIR)/bootblob.bin: $(ELF)
-	rust-objcopy -O binary -R .bss $< $@
+	$(OBJCOPY) -O binary -R .bss $< $@
 
 # Re-run cargo every time.
 .PHONY: $(ELF)


### PR DESCRIPTION
* Makefile.inc (OBJCOPY): New variable.
(bootblob.bin): Use it.

My goal is to make oreboot (optionally) buildable by the official Rust Docker image from Dockerhub, reducing the entire build instructions to just this (without having to install Rust locally before):

```
export PAYLOAD_A=`pwd`/bzImage

TARGET_DIR=`pwd`/src/mainboard/amd/romecrb/target/x86_64-unknown-none/release
mkdir -p "${TARGET_DIR}"
FIXED_DTFS=fixed-dtfs.dtb
dtc src/mainboard/amd/romecrb/fixed-dtfs.dts -O dtb -o "${TARGET_DIR}/${FIXED_DTFS}"

docker pull rustlang/rust:nightly
docker run --rm -e PAYLOAD_A="${PAYLOAD_A}"  -e USER="${USER}" --user "$(id -u)":"$(id -g)" -v "${PWD}:${PWD}" -w "${PWD}" rust-nightly:latest make -C src/mainboard/amd/romecrb OBJCOPY=objcopy

(and then somehow patch the resulting binaries into your specific firmware image--but that's to-be-done regardless)
```

I've checked--`llvm-objcopy`, `rust-objcopy` and (gnu) `objcopy` support the command arguments we need, in exactly the same way.