### PR TITLE
AMD MMIO UART fixes

### DIFF
--- a/src/drivers/uart/src/amdmmio.rs
+++ b/src/drivers/uart/src/amdmmio.rs
@@ -19,6 +19,7 @@ use register::register_bitfields;
 
 const RETRY_COUNT: u32 = 100_000;
 const COM1: usize = 0xfedc9000;
+const COM2: usize = 0xfedca000;
 
 // We fill out as little of this as possible.
 // We're firmware and should never plan to use it
@@ -81,6 +82,10 @@ impl AMDMMIO {
 
     pub fn com1() -> AMDMMIO {
         AMDMMIO { base: COM1 }
+    }
+
+    pub fn com2() -> AMDMMIO {
+        AMDMMIO { base: COM2 }
     }
 
     /// Returns a pointer to the register block

--- a/src/mainboard/amd/romecrb/src/main.rs
+++ b/src/mainboard/amd/romecrb/src/main.rs
@@ -214,9 +214,9 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
     debug.init().unwrap();
     debug.pwrite(b"Welcome to oreboot - debug port 80\r\n", 0).unwrap();
-    let p0 = &mut AMDMMIO::com1();
+    let p0 = &mut AMDMMIO::com2();
     p0.init().unwrap();
-    p0.pwrite(b"Welcome to oreboot - debug port 80\r\n", 0).unwrap();
+    p0.pwrite(b"Welcome to oreboot - com2\r\n", 0).unwrap();
     let s = &mut [debug as &mut dyn Driver, uart0 as &mut dyn Driver, p0 as &mut dyn Driver];
     let console = &mut DoD::new(s);
 


### PR DESCRIPTION
This fixes the AMD MMIO UART drivers, and adds com2.

First, the THRE check is fixed (the check was inverted).

Then the baud rate is set to 115200.

Then, console output is written to COM2 as well.