### PR TITLE
Change i8250 DLAB constant--fixed i8250 serial port baud rate setup

### DIFF
--- a/src/drivers/uart/src/i8250.rs
+++ b/src/drivers/uart/src/i8250.rs
@@ -41,7 +41,7 @@ impl<'a> Driver for I8250<'a> {
         const SCR: usize = 0x07; // Scratch Register                     RW
 
         const FIFOENABLE: u8 = 1;
-        const DLAB: u8 = 0b1000; // Divisor Latch Access bit
+        const DLAB: u8 = 0b1000_0000; // Divisor Latch Access bit
         const EIGHTN1: u8 = 0b0011;
 
         let mut s: [u8; 1] = [0u8; 1];


### PR DESCRIPTION
Previously, the baud rate would NOT be correctly set up when using I8250. That's why it always only worked with a combination of MMIO and I8250 drivers on the same port.

This fixes the AMD 8250 (legacy) baud rate setup--it now works just fine standalone.