### PR TITLE
romecrb: Setup UART0 and UART1 pinctrl, power them on and set the clocks to 1.8 MHz

### DIFF
--- a/src/drivers/uart/src/amdmmio.rs
+++ b/src/drivers/uart/src/amdmmio.rs
@@ -98,7 +98,7 @@ impl Driver for AMDMMIO {
     fn init(&mut self) -> Result<()> {
         self.lcr.write(LCR::BITSPARITY::EIGHTN1 + LCR::DLAB::BaudRate);
         self.dlm.set(0);
-        self.d.set(26); // approx. 115200
+        self.d.set(1); // approx. 115200
         self.lcr.write(LCR::BITSPARITY::EIGHTN1 + LCR::DLAB::Data);
         self.dlm.set(0); // Just clear the IER to be safe.
         Ok(())

--- a/src/mainboard/amd/romecrb/src/mainboard.rs
+++ b/src/mainboard/amd/romecrb/src/mainboard.rs
@@ -2,6 +2,7 @@
  * This file is part of the coreboot project.
  *
  * Copyright (C) 2020 Google Inc.
+ * Copyright (C) 2021 DATACOM Electronics GmbH
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,13 +14,48 @@
  * GNU General Public License for more details.
  */
 
+#![allow(non_upper_case_globals)]
+
 use clock::ClockNode;
 use core::ptr;
 use model::*;
 use x86_64::registers::model_specific::Msr;
 
+const SMB_UART_CONFIG: u32 = 0xfed8_00fc;
+const SMB_UART_1_8M_SHIFT: u8 = 28;
+const SMB_UART_CONFIG_UART0_1_8M: u32 = 1 << SMB_UART_1_8M_SHIFT;
+const SMB_UART_CONFIG_UART1_1_8M: u32 = 1 << (SMB_UART_1_8M_SHIFT + 1);
+
 const FCH_UART_LEGACY_DECODE: u32 = 0xfedc0020;
 const FCH_LEGACY_3F8_SH: u16 = 1 << 3;
+//const FCH_LEGACY_2F8_SH: u16 = 1 << 1;
+
+// See coreboot:src/soc/amd/common/block/include/amdblocks/acpimmio_map.h
+
+const ACPI_MMIO_BASE: u32 = 0xfed8_0000;
+const IOMUX_BASE: u32 = ACPI_MMIO_BASE + 0xd00; // Note: 256 u8 block--one u8 per pinctrl
+const AOAC_BASE: u32 = ACPI_MMIO_BASE + 0x1e00;
+
+// See coreboot:src/soc/amd/common/block/include/amdblocks/aoac.h
+
+const FCH_AOACx40_D3_CONTROL: u32 = AOAC_BASE + 0x40; // Note: 32 times (control: u8, status: u8) block
+const AOAC_PWR_ON_DEV: u8 = 1 << 3;
+
+/* TODO: Use D3 State:
+FCH_AOAC_PWR_RST_STATE        BIT(0)
+FCH_AOAC_RST_CLK_OK_STATE     BIT(1)
+FCH_AOAC_RST_B_STATE          BIT(2)
+FCH_AOAC_DEV_OFF_GATING_STATE BIT(3)
+FCH_AOAC_D3COLD               BIT(4)
+FCH_AOAC_CLK_OK_STATE         BIT(5)
+FCH_AOAC_STAT0                BIT(6)
+FCH_AOAC_STAT1                BIT(7) */
+
+// See coreboot:src/soc/amd/picasso/include/soc/southbridge.h
+
+const FCH_AOAC_DEV_UART0: u8 = 11;
+const FCH_AOAC_DEV_UART1: u8 = 12;
+const FCH_AOAC_DEV_AMBA: u8 = 17;
 
 // It's kind of a shame, but every single pci crate I've looked at is
 // basically close to useless. Unless I'm missing something,
@@ -70,6 +106,15 @@ fn peek32(a: u32) -> u32 {
         return ptr::read_volatile(y);
     }
 }
+
+// Read u8 from address A, reset bits from RESET_MASK, set bits from SET_MASK, write result back to address A
+fn pokers8(a: u32, reset_mask: u8, set_mask: u8) -> () {
+    let y = a as *mut u8;
+    unsafe {
+        ptr::write_volatile(y, (ptr::read_volatile(y) & !reset_mask) | set_mask);
+    }
+}
+
 /// Write 32 bits to port
 unsafe fn outl(port: u16, val: u32) {
     llvm_asm!("outl %eax, %dx" :: "{dx}"(port), "{al}"(val));
@@ -91,24 +136,53 @@ impl MainBoard {
     }
 }
 
+fn d3_control_power_on(n: u8) -> () {
+    if n < 32 {
+        pokers8(FCH_AOACx40_D3_CONTROL + u32::from(n * 2), 0, AOAC_PWR_ON_DEV);
+    }
+}
+
+fn pinctrl(pin: u8, mode: u8) -> () {
+    // IOMUX (IOMUX total: 256 registers; one u8 per GPIO)
+    pokers8(IOMUX_BASE + u32::from(pin), 3, mode);
+}
+
 impl Driver for MainBoard {
     fn init(&mut self) -> Result<()> {
-        // Knowledge from coreboot to get minimal serial working.
-        // GPIO defaults are fine.
-        // clock default is NOT fine.
-        // Need to set it to 8 mhz.
-        // this should fuck up uart output but we'll see.
+        // Knowledge from coreboot to get minimal serials working.
+        // clock defaults are NOT fine.
         //uart_ctrl = sm_pci_read32(SMB_UART_CONFIG);
         //uart_ctrl |= 1 << (SMB_UART_1_8M_SHIFT + idx);
         //sm_pci_write32(SMB_UART_CONFIG, uart_ctrl);
-        // FED8000 is the basic MMIO space.
-        // fed800fc is the uart control reg.
-        // bit 28 is the bit which sets it between 48m and 1.8m
         // we want 1.8m. They made oddball 48m default. Stupid.
-        let mut uc = peek32(0xfed800fc);
-        uc = uc | (1 << 28);
-        poke32(0xfed800fc, uc);
-        // Set up the legacy decode.
+        let mut uc = peek32(SMB_UART_CONFIG);
+        uc = uc | SMB_UART_CONFIG_UART0_1_8M;
+        uc = uc | SMB_UART_CONFIG_UART1_1_8M;
+        poke32(SMB_UART_CONFIG, uc);
+
+        d3_control_power_on(FCH_AOAC_DEV_AMBA); // Note: It's on by default
+        d3_control_power_on(FCH_AOAC_DEV_UART0); // Note: It's on by default
+        d3_control_power_on(FCH_AOAC_DEV_UART1); // Note: It's on by default
+
+        // UART 0
+
+        // See coreboot:src/soc/amd/picasso/include/soc/gpio.h
+        pinctrl(135, 0); // [UART0_CTS_L, UART2_RXD, EGPIO135][0]; Note: The reset default is 0
+        pinctrl(136, 0); // [UART0_RXD, EGPIO136][0]; Note: The reset default is 0
+        pinctrl(137, 0); // [UART0_RTS_L, EGPIO137][0]
+        pinctrl(138, 0); // [UART0_TXD, EGPIO138][0]
+        pinctrl(139, 0); // [UART0_INTR, AGPIO139][0]; Note: The reset default is 0
+
+        // UART 1
+
+        // See coreboot:src/soc/amd/picasso/include/soc/gpio.h
+        pinctrl(140, 0); // [UART1_CTS_L_UART3_TXD, EGPIO140][0]; Note: The reset default is 0
+        pinctrl(141, 0); // [UART1_RXD, EGPIO141][0]; Note: The reset default is 0
+        pinctrl(142, 0); // [UART1_RTS_L, EGPIO142][0]
+        pinctrl(143, 0); // [UART1_TXD, EGPIO143][0]
+        pinctrl(144, 0); // [UART1_INTR, AGPIO144][0]; Note: The reset default is 0
+
+        // Set up the legacy decode for UART 0.
         poke16(FCH_UART_LEGACY_DECODE, FCH_LEGACY_3F8_SH);
         let mut msr0 = Msr::new(0x1b);
         unsafe {


### PR DESCRIPTION
This patch completes the UART setup for AMD romecrb.

It sets up UART0 and UART1. It does the pinctrl setup, powers the UART blocks on, powers AMBA on and sets the UART clocks to 1.8 MHz.
