### PR TITLE
Update x86_64-unknown-none data-layout to upstream

### DIFF
--- a/src/custom_targets/x86_64-unknown-none.json
+++ b/src/custom_targets/x86_64-unknown-none.json
@@ -3,7 +3,7 @@
     "target-endian": "little",
     "target-pointer-width": "64",
     "target-c-int-width": "32",
-    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "os": "none",
     "env": "",


### PR DESCRIPTION
LLVM updated all x86 targets to allow mixed pointer sizes
(https://reviews.llvm.org/D64931). Our misalignment was causing a
warning.

Fixes oreboot#346.

Signed-off-by: Nickolas Fotopoulos <foton@google.com>