### PR TITLE
Factor out toolchain overrides into rust-toolchain file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BROKEN := \
 
 MAINBOARDS := $(filter-out $(BROKEN), $(wildcard src/mainboard/*/*/Makefile))
 
-TOOLCHAIN_VER := nightly-2020-10-25
+TOOLCHAIN_VER := $(shell grep channel rust-toolchain | grep -e '".*"' -o)
 BINUTILS_VER := 0.3.2
 
 .PHONY: mainboards $(MAINBOARDS)
@@ -29,12 +29,6 @@ $(MAINBOARDS):
 	cd $(dir $@) && make
 
 firsttime:
-	rustup override set $(TOOLCHAIN_VER)
-	rustup component add rust-src llvm-tools-preview rustfmt clippy
-	rustup target add riscv64imac-unknown-none-elf
-	rustup target add riscv32imc-unknown-none-elf
-	rustup target add armv7r-none-eabi
-	rustup target add aarch64-unknown-none-softfloat
 	cargo install $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
 
 firsttime_fsp:
@@ -42,6 +36,8 @@ firsttime_fsp:
 
 debiansysprepare:
 	sudo apt-get install device-tree-compiler pkg-config libssl-dev llvm-dev libclang-dev clang
+	# --default-toolchain is purely an optimization to avoid downloading stable Rust first.
+	# -y makes it non-interactive.
 	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $(TOOLCHAIN_VER)
 
 .PHONY: ciprepare debiansysprepare firsttime

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,9 @@
+[toolchain]
+channel = "nightly-2020-10-25"
+components = [ "rust-src", "llvm-tools-preview", "rustfmt", "clippy" ]
+targets = [
+  "riscv64imac-unknown-none-elf",
+  "riscv32imc-unknown-none-elf",
+  "armv7r-none-eabi",
+  "aarch64-unknown-none-softfloat",
+]


### PR DESCRIPTION
The `rust-toolchain` file appears to be the official way to check toolchain overrides into version control. https://rust-lang.github.io/rustup/overrides.html?highlight=toml#the-toolchain-file

It appeals to me because it separates data from code.

Fixes #275.

Signed-off-by: Nickolas Fotopoulos <foton@google.com>