### PR TITLE
romecrb: Use vcell for registers (instead of integers).

### DIFF
--- a/src/mainboard/amd/romecrb/Cargo.toml
+++ b/src/mainboard/amd/romecrb/Cargo.toml
@@ -19,6 +19,7 @@ register = "0.3.2"
 static-ref = "0.1.1"
 postcard = "0.4.3"
 x86_64 = "0.12.2"
+vcell = "0.1.2"
 
 [dependencies.uart]
 path = "../../../drivers/uart"

--- a/src/mainboard/amd/romecrb/src/mainboard.rs
+++ b/src/mainboard/amd/romecrb/src/mainboard.rs
@@ -17,28 +17,33 @@
 #![allow(non_upper_case_globals)]
 
 use clock::ClockNode;
+use core::ops::BitAnd;
+use core::ops::BitOr;
+use core::ops::Not;
 use core::ptr;
 use model::*;
+use vcell::VolatileCell;
 use x86_64::registers::model_specific::Msr;
 
-const SMB_UART_CONFIG: u32 = 0xfed8_00fc;
+const SMB_UART_CONFIG: *const VolatileCell<u32> = 0xfed8_00fc as *const _;
 const SMB_UART_1_8M_SHIFT: u8 = 28;
 const SMB_UART_CONFIG_UART0_1_8M: u32 = 1 << SMB_UART_1_8M_SHIFT;
 const SMB_UART_CONFIG_UART1_1_8M: u32 = 1 << (SMB_UART_1_8M_SHIFT + 1);
 
-const FCH_UART_LEGACY_DECODE: u32 = 0xfedc0020;
+const FCH_UART_LEGACY_DECODE: *const VolatileCell<u16> = 0xfedc_0020 as *const _;
 const FCH_LEGACY_3F8_SH: u16 = 1 << 3;
 //const FCH_LEGACY_2F8_SH: u16 = 1 << 1;
 
 // See coreboot:src/soc/amd/common/block/include/amdblocks/acpimmio_map.h
 
-const ACPI_MMIO_BASE: u32 = 0xfed8_0000;
-const IOMUX_BASE: u32 = ACPI_MMIO_BASE + 0xd00; // Note: 256 u8 block--one u8 per pinctrl
-const AOAC_BASE: u32 = ACPI_MMIO_BASE + 0x1e00;
+const ACPI_MMIO_BASE: usize = 0xfed8_0000;
+//const IOMUX_BASE: *mut u8 = (ACPI_MMIO_BASE + 0xd00) as *mut _;
+const IOMUX_BASE: *const [VolatileCell<u8>; 256] = (ACPI_MMIO_BASE + 0xd00) as *const _; // Note: 256 u8 block--one u8 per pinctrl
+const AOAC_BASE: usize = ACPI_MMIO_BASE + 0x1e00;
 
 // See coreboot:src/soc/amd/common/block/include/amdblocks/aoac.h
 
-const FCH_AOACx40_D3_CONTROL: u32 = AOAC_BASE + 0x40; // Note: 32 times (control: u8, status: u8) block
+const FCH_AOACx40_D3_CONTROL: *const [VolatileCell<u8>; 64] = (AOAC_BASE + 0x40) as *const _; // Note: 32 times (control: u8, status: u8) block
 const AOAC_PWR_ON_DEV: u8 = 1 << 3;
 
 /* TODO: Use D3 State:
@@ -86,33 +91,21 @@ fn smn_write(a: u32, v: u32) {
 }
 
 // end SMN
-fn poke16(a: u32, v: u16) -> () {
-    let y = a as *mut u16;
-    unsafe {
-        ptr::write_volatile(y, v);
-    }
+
+unsafe fn poke<T>(a: *mut T, v: T) -> () {
+    ptr::write_volatile(a, v);
 }
 
-fn poke32(a: u32, v: u32) -> () {
-    let y = a as *mut u32;
-    unsafe {
-        ptr::write_volatile(y, v);
-    }
+// Read T from VolatileCell A, reset bits from RESET_MASK, set bits from SET_MASK, write result back to address A
+unsafe fn pokers32(a: *mut u32, reset_mask: u32, set_mask: u32) -> () {
+    ptr::write_volatile(a, (ptr::read_volatile(a) & !reset_mask) | set_mask);
 }
 
-fn peek32(a: u32) -> u32 {
-    let y = a as *mut u32;
-    unsafe {
-        return ptr::read_volatile(y);
-    }
-}
-
-// Read u8 from address A, reset bits from RESET_MASK, set bits from SET_MASK, write result back to address A
-fn pokers8(a: u32, reset_mask: u8, set_mask: u8) -> () {
-    let y = a as *mut u8;
-    unsafe {
-        ptr::write_volatile(y, (ptr::read_volatile(y) & !reset_mask) | set_mask);
-    }
+unsafe fn pokers<T>(a: *const VolatileCell<T>, reset_mask: T, set_mask: T) -> ()
+where
+    T: Copy + Not<Output = T> + BitAnd<Output = T> + BitOr<Output = T>,
+{
+    (*a).set(((*a).get() & !reset_mask) | set_mask);
 }
 
 /// Write 32 bits to port
@@ -138,75 +131,77 @@ impl MainBoard {
 
 fn d3_control_power_on(n: u8) -> () {
     if n < 32 {
-        pokers8(FCH_AOACx40_D3_CONTROL + u32::from(n * 2), 0, AOAC_PWR_ON_DEV);
+        unsafe {
+            pokers(&(*FCH_AOACx40_D3_CONTROL)[usize::from(n * 2)], 0, AOAC_PWR_ON_DEV);
+        }
     }
 }
 
 fn pinctrl(pin: u8, mode: u8) -> () {
     // IOMUX (IOMUX total: 256 registers; one u8 per GPIO)
-    pokers8(IOMUX_BASE + u32::from(pin), 3, mode);
+    unsafe {
+        pokers(&(*IOMUX_BASE)[usize::from(pin)], 3, mode);
+    }
 }
 
 impl Driver for MainBoard {
     fn init(&mut self) -> Result<()> {
-        // Knowledge from coreboot to get minimal serials working.
-        // clock defaults are NOT fine.
-        //uart_ctrl = sm_pci_read32(SMB_UART_CONFIG);
-        //uart_ctrl |= 1 << (SMB_UART_1_8M_SHIFT + idx);
-        //sm_pci_write32(SMB_UART_CONFIG, uart_ctrl);
-        // we want 1.8m. They made oddball 48m default. Stupid.
-        let mut uc = peek32(SMB_UART_CONFIG);
-        uc = uc | SMB_UART_CONFIG_UART0_1_8M;
-        uc = uc | SMB_UART_CONFIG_UART1_1_8M;
-        poke32(SMB_UART_CONFIG, uc);
-
-        d3_control_power_on(FCH_AOAC_DEV_AMBA); // Note: It's on by default
-        d3_control_power_on(FCH_AOAC_DEV_UART0); // Note: It's on by default
-        d3_control_power_on(FCH_AOAC_DEV_UART1); // Note: It's on by default
-
-        // UART 0
-
-        // See coreboot:src/soc/amd/picasso/include/soc/gpio.h
-        pinctrl(135, 0); // [UART0_CTS_L, UART2_RXD, EGPIO135][0]; Note: The reset default is 0
-        pinctrl(136, 0); // [UART0_RXD, EGPIO136][0]; Note: The reset default is 0
-        pinctrl(137, 0); // [UART0_RTS_L, EGPIO137][0]
-        pinctrl(138, 0); // [UART0_TXD, EGPIO138][0]
-        pinctrl(139, 0); // [UART0_INTR, AGPIO139][0]; Note: The reset default is 0
-
-        // UART 1
-
-        // See coreboot:src/soc/amd/picasso/include/soc/gpio.h
-        pinctrl(140, 0); // [UART1_CTS_L_UART3_TXD, EGPIO140][0]; Note: The reset default is 0
-        pinctrl(141, 0); // [UART1_RXD, EGPIO141][0]; Note: The reset default is 0
-        pinctrl(142, 0); // [UART1_RTS_L, EGPIO142][0]
-        pinctrl(143, 0); // [UART1_TXD, EGPIO143][0]
-        pinctrl(144, 0); // [UART1_INTR, AGPIO144][0]; Note: The reset default is 0
-
-        // Set up the legacy decode for UART 0.
-        poke16(FCH_UART_LEGACY_DECODE, FCH_LEGACY_3F8_SH);
-        let mut msr0 = Msr::new(0x1b);
         unsafe {
-            let v = msr0.read() | 0x900;
-            msr0.write(v);
-            //let v = msr.read() | 0xd00;
-            //write!(w, "NOT ENABLING x2apic!!!\n\r");
-            //msr.write(v);
+            // Knowledge from coreboot to get minimal serials working.
+            // clock defaults are NOT fine.
+            //uart_ctrl = sm_pci_read32(SMB_UART_CONFIG);
+            //uart_ctrl |= 1 << (SMB_UART_1_8M_SHIFT + idx);
+            //sm_pci_write32(SMB_UART_CONFIG, uart_ctrl);
+            // we want 1.8m. They made oddball 48m default. Stupid.
+            pokers(SMB_UART_CONFIG, 0, SMB_UART_CONFIG_UART0_1_8M | SMB_UART_CONFIG_UART1_1_8M);
+
+            d3_control_power_on(FCH_AOAC_DEV_AMBA); // Note: It's on by default
+            d3_control_power_on(FCH_AOAC_DEV_UART0); // Note: It's on by default
+            d3_control_power_on(FCH_AOAC_DEV_UART1); // Note: It's on by default
+
+            // UART 0
+
+            // See coreboot:src/soc/amd/picasso/include/soc/gpio.h
+            pinctrl(135, 0); // [UART0_CTS_L, UART2_RXD, EGPIO135][0]; Note: The reset default is 0
+            pinctrl(136, 0); // [UART0_RXD, EGPIO136][0]; Note: The reset default is 0
+            pinctrl(137, 0); // [UART0_RTS_L, EGPIO137][0]
+            pinctrl(138, 0); // [UART0_TXD, EGPIO138][0]
+            pinctrl(139, 0); // [UART0_INTR, AGPIO139][0]; Note: The reset default is 0
+
+            // UART 1
+
+            // See coreboot:src/soc/amd/picasso/include/soc/gpio.h
+            pinctrl(140, 0); // [UART1_CTS_L_UART3_TXD, EGPIO140][0]; Note: The reset default is 0
+            pinctrl(141, 0); // [UART1_RXD, EGPIO141][0]; Note: The reset default is 0
+            pinctrl(142, 0); // [UART1_RTS_L, EGPIO142][0]
+            pinctrl(143, 0); // [UART1_TXD, EGPIO143][0]
+            pinctrl(144, 0); // [UART1_INTR, AGPIO144][0]; Note: The reset default is 0
+
+            // Set up the legacy decode for UART 0.
+            (*FCH_UART_LEGACY_DECODE).set(FCH_LEGACY_3F8_SH);
+            let mut msr0 = Msr::new(0x1b);
+            unsafe {
+                let v = msr0.read() | 0x900;
+                msr0.write(v);
+                //let v = msr.read() | 0xd00;
+                //write!(w, "NOT ENABLING x2apic!!!\n\r");
+                //msr.write(v);
+            }
+            // IOAPIC
+            //     wmem fed80300 e3070b77
+            //    wmem fed00010 3
+            poke(0xfed80300 as *mut u32, 0xe3070b77); //FCH PM DECODE EN
+            poke(0xfed00010 as *mut u32, 3); //HPETCONFIG
+            pokers32(0xfed00010 as *mut u32, 0, 8);
+            // THis is likely not needed but.
+            //poke32(0xfed00108, 0x5b03d997);
+
+            // enable ioapic redirection
+            // IOHC::IOAPIC_BASE_ADDR_LO
+            smn_write(0x13B1_02f0, 0xFEC0_0001);
+
+            Ok(())
         }
-        // IOAPIC
-        //     wmem fed80300 e3070b77
-        //    wmem fed00010 3
-        poke32(0xfed80300, 0xe3070b77); //FCH PM DECODE EN
-        poke32(0xfed00010, 3); //HPETCONFIG
-        let i = peek32(0xfed00010);
-        poke32(0xfed00010, i | 8);
-        // THis is likely not needed but.
-        //poke32(0xfed00108, 0x5b03d997);
-
-        // enable ioapic redirection
-        // IOHC::IOAPIC_BASE_ADDR_LO
-        smn_write(0x13B1_02f0, 0xFEC0_0001);
-
-        Ok(())
     }
 
     fn pread(&self, _data: &mut [u8], _offset: usize) -> Result<usize> {


### PR DESCRIPTION
Signed-off-by: Danny Milosavljevic <danny.milo@datacom.wien>
