### PR TITLE
hsmp: Mark functions safe.

### DIFF
--- a/src/soc/amd/rome/src/lib.rs
+++ b/src/soc/amd/rome/src/lib.rs
@@ -7,30 +7,28 @@ pub mod pci;
 
 pub fn soc_init(w: &mut impl core::fmt::Write) -> Result<(), &'static str> {
     let hsmp = hsmp::HSMP::new(0);
-    unsafe {
-        match hsmp.test(42) {
-            Ok(v) => {
-                write!(w, "HSMP test(42) result: {}\r\n", v).unwrap();
-            }
-            Err(e) => {
-                write!(w, "HSMP test(42) error: {}\r\n", e).unwrap();
-            }
+    match hsmp.test(42) {
+        Ok(v) => {
+            write!(w, "HSMP test(42) result: {}\r\n", v).unwrap();
         }
-        match hsmp.smu_version() {
-            Ok((major, minor)) => {
-                write!(w, "HSMP smu version result: {}.{}\r\n", major, minor).unwrap();
-            }
-            Err(e) => {
-                write!(w, "HSMP smu version error: {}\r\n", e).unwrap();
-            }
+        Err(e) => {
+            write!(w, "HSMP test(42) error: {}\r\n", e).unwrap();
         }
-        match hsmp.interface_version() {
-            Ok((major, minor)) => {
-                write!(w, "HSMP interface version result: {}.{}\r\n", major, minor).unwrap();
-            }
-            Err(e) => {
-                write!(w, "HSMP interface version error: {}\r\n", e).unwrap();
-            }
+    }
+    match hsmp.smu_version() {
+        Ok((major, minor)) => {
+            write!(w, "HSMP smu version result: {}.{}\r\n", major, minor).unwrap();
+        }
+        Err(e) => {
+            write!(w, "HSMP smu version error: {}\r\n", e).unwrap();
+        }
+    }
+    match hsmp.interface_version() {
+        Ok((major, minor)) => {
+            write!(w, "HSMP interface version result: {}.{}\r\n", major, minor).unwrap();
+        }
+        Err(e) => {
+            write!(w, "HSMP interface version error: {}\r\n", e).unwrap();
         }
     }
     Ok(())


### PR DESCRIPTION
After reading some more Rust docs, I think those functions are technically not unsafe in the sense of Rust.

So this marks them safe.