### PR TITLE
Picasso: Remove unnecessary llvm asm directive.

### DIFF
--- a/src/soc/amd/picasso/src/lib.rs
+++ b/src/soc/amd/picasso/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(llvm_asm)]
 
 pub mod mp1;
 


### PR DESCRIPTION
Since the module isn't using llvm asm, remove llvm asm directive.