### PR TITLE
make soc a part

### DIFF
--- a/src/soc/amd/rome/src/lib.rs
+++ b/src/soc/amd/rome/src/lib.rs
@@ -5,33 +5,47 @@ pub mod hsmp;
 
 use hsmp::HSMP;
 
-pub fn soc_init(w: &mut impl core::fmt::Write) -> Result<(), &'static str> {
-    let hsmp = HSMP::new();
-    match hsmp.test(42) {
-        Ok(v) => {
-            write!(w, "HSMP test(42) result: {:x?}\r\n", v).unwrap();
-        }
-        Err(e) => {
-            write!(w, "HSMP test(42) error: {:x?}\r\n", e).unwrap();
-        }
+pub struct SOC {}
+
+impl SOC {
+    pub fn new() -> SOC {
+        Self {}
     }
-    match hsmp.smu_version() {
-        Ok(v) => {
-            write!(w, "HSMP smu version result: {:x?}\r\n", v).unwrap();
+
+    pub fn init(&mut self, w: &mut impl core::fmt::Write) -> Result<(), &'static str> {
+        let hsmp = HSMP::new();
+        match hsmp.test(42) {
+            Ok(v) => {
+                write!(w, "HSMP test(42) result: {:x?}\r\n", v).unwrap();
+            }
+            Err(e) => {
+                write!(w, "HSMP test(42) error: {:x?}\r\n", e).unwrap();
+            }
         }
-        Err(e) => {
-            write!(w, "HSMP smu version error: {:x?}\r\n", e).unwrap();
+        match hsmp.smu_version() {
+            Ok(v) => {
+                write!(w, "HSMP smu version result: {:x?}\r\n", v).unwrap();
+            }
+            Err(e) => {
+                write!(w, "HSMP smu version error: {:x?}\r\n", e).unwrap();
+            }
         }
+        match hsmp.interface_version() {
+            Ok(v) => {
+                write!(w, "HSMP interface version result: {:x?}\r\n", v).unwrap();
+            }
+            Err(e) => {
+                write!(w, "HSMP interface version error: {:x?}\r\n", e).unwrap();
+            }
+        }
+        let topology = df::FabricTopology::new();
+        write!(w, "Topology: {:?}\r\n", topology).unwrap();
+        Ok(())
     }
-    match hsmp.interface_version() {
-        Ok(v) => {
-            write!(w, "HSMP interface version result: {:x?}\r\n", v).unwrap();
-        }
-        Err(e) => {
-            write!(w, "HSMP interface version error: {:x?}\r\n", e).unwrap();
-        }
+}
+
+impl Default for SOC {
+    fn default() -> Self {
+        Self::new()
     }
-    let topology = df::FabricTopology::new();
-    write!(w, "Topology: {:?}\r\n", topology).unwrap();
-    Ok(())
 }


### PR DESCRIPTION
This is prior to adding all the little MPx parts to the system.

They are properly part of the soc.

As a first pass, set up a soc struct and set up its new and init
methods.

Longer term, the cpu_init ought to be called from the soc, but one thing
at a time.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>