### PR TITLE
soc/amd/rome: Add the other MPs to the SOC

### DIFF
--- a/src/arch/x86/x86_64/Cargo.lock
+++ b/src/arch/x86/x86_64/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "model",
  "print",
  "util",
+ "vcell",
  "wrappers",
 ]
 
@@ -24,6 +25,12 @@ dependencies = [
 [[package]]
 name = "util"
 version = "0.1.0"
+
+[[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
 name = "wrappers"

--- a/src/drivers/uart/Cargo.lock
+++ b/src/drivers/uart/Cargo.lock
@@ -4,15 +4,17 @@
 name = "as-slice"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293dac66b274fab06f95e7efb05ec439a6b70136081ea522d270bc351ae5bb27"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "clock"
@@ -22,34 +24,38 @@ version = "0.1.0"
 name = "generic-array"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8107dafa78c80c848b71b60133954b4a58609a3a1a5f9af037ecc7f67280f369"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
 name = "hash32"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
 ]
 
 [[package]]
 name = "heapless"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ae80bbc62401ae8096976857172507cadbd2200f36670e5144634360a05959"
 dependencies = [
- "as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "as-slice",
+ "generic-array 0.11.1",
+ "hash32",
 ]
 
 [[package]]
@@ -60,43 +66,51 @@ version = "0.1.0"
 name = "register"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469bb5ddde81d67fb8bba4e14d77689b8166cfd077abe7530591cefe29d05823"
 dependencies = [
- "tock-registers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tock-registers",
 ]
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+
+[[package]]
+name = "timer"
+version = "0.1.0"
+dependencies = [
+ "model",
+ "register",
+ "vcell",
+]
 
 [[package]]
 name = "tock-registers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c758f5195a2e0df9d9fecf6f506506b2766ff74cf64db1e995c87e2761a5c3e2"
 
 [[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 
 [[package]]
 name = "uart"
 version = "0.1.0"
 dependencies = [
- "clock 0.1.0",
- "heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "model 0.1.0",
- "register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock",
+ "heapless",
+ "model",
+ "register",
+ "timer",
 ]
 
-[metadata]
-"checksum as-slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "293dac66b274fab06f95e7efb05ec439a6b70136081ea522d270bc351ae5bb27"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8107dafa78c80c848b71b60133954b4a58609a3a1a5f9af037ecc7f67280f369"
-"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
-"checksum heapless 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ae80bbc62401ae8096976857172507cadbd2200f36670e5144634360a05959"
-"checksum register 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "469bb5ddde81d67fb8bba4e14d77689b8166cfd077abe7530591cefe29d05823"
-"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum tock-registers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c758f5195a2e0df9d9fecf6f506506b2766ff74cf64db1e995c87e2761a5c3e2"
-"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+[[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"

--- a/src/soc/amd/rome/Cargo.lock
+++ b/src/soc/amd/rome/Cargo.lock
@@ -93,6 +93,13 @@ name = "model"
 version = "0.1.0"
 
 [[package]]
+name = "mp"
+version = "0.1.0"
+dependencies = [
+ "smn",
+]
+
+[[package]]
 name = "pci"
 version = "0.1.0"
 dependencies = [
@@ -108,11 +115,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "smn"
+version = "0.1.0"
+dependencies = [
+ "arch",
+ "vcell",
+]
+
+[[package]]
 name = "soc"
 version = "0.1.0"
 dependencies = [
  "arch",
  "df",
+ "mp",
  "pci",
  "vcell",
 ]

--- a/src/soc/amd/rome/src/lib.rs
+++ b/src/soc/amd/rome/src/lib.rs
@@ -4,17 +4,55 @@
 pub mod hsmp;
 use hsmp::HSMP;
 
+use mp::mpmailbox::MPMailbox;
+
 pub struct SOC {
     hsmp: HSMP,
+    // TODO: rename these when we know what they do
+    mp0: MPMailbox<8>,
+    mp1: MPMailbox<8>,
+    mp2: MPMailbox<8>,
+    mp3: MPMailbox<8>,
 }
 
 impl SOC {
     pub fn new() -> SOC {
         let hsmp = HSMP::new();
-        Self { hsmp }
+        let mp0 = MPMailbox::<8>::new(0x3B1_0520, 0x3B1_002C, 0x3B1_09B8);
+        let mp1 = MPMailbox::<8>::new(0x3B1_0524, 0x3B1_0570, 0x3B1_0A40);
+        let mp2 = MPMailbox::<8>::new(0x3B1_0528, 0x3B1_0574, 0x3B1_0960);
+        let mp3 = MPMailbox::<8>::new(0x3B1_0530, 0x3B1_057C, 0x3B1_09C4);
+        Self { hsmp, mp0, mp1, mp2, mp3 }
     }
 
     pub fn init(&mut self, w: &mut impl core::fmt::Write) -> Result<(), &'static str> {
+        let mps = [&self.mp0, &self.mp1, &self.mp2, &self.mp3];
+        for mp in mps.iter() {
+            match mp.test(42) {
+                Ok(v) => {
+                    write!(w, "mp result: {:x?}\r\n", v).unwrap();
+                }
+                Err(e) => {
+                    write!(w, "mp test(42) error: {:x?}\r\n", e).unwrap();
+                }
+            }
+            match mp.smu_version() {
+                Ok(v) => {
+                    write!(w, "mp smu version result: {:x?}\r\n", v).unwrap();
+                }
+                Err(e) => {
+                    write!(w, "mp smu version error: {:x?}\r\n", e).unwrap();
+                }
+            }
+            // match mp.interface_version() {
+            //     Ok(v) => {
+            //         write!(w, "mp interface version result: {:x?}\r\n", v).unwrap();
+            //     }
+            //     Err(e) => {
+            //         write!(w, "mp interface version error: {:x?}\r\n", e).unwrap();
+            //     }
+            // }
+        }
         match self.hsmp.test(42) {
             Ok(v) => {
                 write!(w, "HSMP test(42) result: {:x?}\r\n", v).unwrap();


### PR DESCRIPTION
builds and boots. Runs test42 and smu_version for the first 4 MPs.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>