### PR TITLE
Rome: Provide different stacks for different cores.

### DIFF
--- a/src/mainboard/amd/romecrb/src/bootblock.S
+++ b/src/mainboard/amd/romecrb/src/bootblock.S
@@ -79,9 +79,7 @@ gdt_end:
 3:
 	movb $0x42, %al
 	outb %al, $0x80
-	movw $0x3F8, %dx
   movb $0xAA, %al
-  call p4
 	// TOS contains a pointer to the gdt descriptor
 	popl %eax
 	// The low 4 bits of %eax are 3.
@@ -103,12 +101,6 @@ gdt_end:
 	outb %al, $0x80
 	popl %eax
 	lgdt (%eax)
-
-  pushl %edx /* Print num */
-  movw $0x3f8, %dx
-  movb $'1', %al
-  outb %al, %dx
-  popl %edx /* Print num */
 
 	movb $0xbf, %al
 	outb %al, $0x80
@@ -132,65 +124,6 @@ gdt_end:
 
 	/* Now that we are in protected mode jump to a 32 bit code segment. */
 	ljmpl	$0x18, $__protected_start
-
-p4:
-  push %ebx
-  push %eax // Input in ax
-
-  movw $0x3FD, %dx  // Check LCR while transmit buffer is full
-  1: inb %dx, %al
-  andb $0x20, %al
-  cmp $0x20, %al
-  jl 1b             // End check
-
-  pop %eax
-  push %eax // Restore input to ax
-
-  movw $0x3F8, %dx  // UART port
-  rorb $4, %al      // Upper nibble first
-  andb $0x0f, %al
-  cmp $9, %al
-  jg 1f
-  add $'0', %al
-  jmp 2f
-  1: add $0x37, %al
-  2: outb %al, %dx
-
-  movw $0x3FD, %dx  // LCR check
-  1: inb %dx, %al
-  andb $0x20, %al
-  cmp $0x20, %al
-  jl 1b             // End check
-
-  pop %eax
-  push %eax // Restore input to ax
-
-  movw $0x3F8, %dx  // UART port
-  andb $0x0f, %al
-  cmp $9, %al
-  jg 1f
-  add $'0', %al
-  jmp 2f
-  1: add $0x37, %al
-  2: outb %al, %dx
-
-  movw $0x3FD, %dx  // LCR check
-  1: inb %dx, %al
-  andb $0x20, %al
-  cmp $0x20, %al
-  jl 1b             // End check
-
-  movw $0x3F8, %dx  // UART port
-  movb $0x0A, %al // \r\n after a print
-  outb %al, %dx
-  movb $0x0D, %al
-  outb %al, %dx
-
-  pop %eax
-  pop %ebx
-  ret
-
-
 
 	// TODO: should set accessed and dirty bits in gdt entries
 	// so CPU does not try to write them to ROM?
@@ -269,7 +202,6 @@ lme:
 //	shrl $24, %eax
 //	outb    %al, $0x80
 //1: jmp 1b
-  movw $0x3f8, %dx /* Print num */
 	movl	%cr0, %eax
 	// yeah yeah repeat defines. It's ok. They've been constant for almost 40 years.
 	// view screen scrape from the docs. Includes of 40-year-old constants are a PITA.

--- a/src/mainboard/amd/romecrb/src/main.rs
+++ b/src/mainboard/amd/romecrb/src/main.rs
@@ -16,7 +16,6 @@ use raw_cpuid::CpuId;
 use smn::{smn_read, smn_write};
 use soc::SOC;
 use uart::amdmmio::AMDMMIO;
-use uart::debug_port::DebugPort;
 use uart::i8250::I8250;
 mod mainboard;
 use mainboard::MainBoard;
@@ -298,16 +297,16 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     let post = &mut IOPort;
     let uart0 = &mut I8250::new(0x3f8, 0, io);
     uart0.init().unwrap();
-    let debug_io = &mut IOPort;
-    let debug = &mut DebugPort::new(0x80, debug_io);
+    //let debug_io = &mut IOPort;
+    //let debug = &mut DebugPort::new(0x80, debug_io);
     uart0.init().unwrap();
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
-    debug.init().unwrap();
-    debug.pwrite(b"Welcome to oreboot - debug port 80\r\n", 0).unwrap();
+    //debug.init().unwrap();
+    //debug.pwrite(b"Welcome to oreboot - debug port 80\r\n", 0).unwrap();
     let p0 = &mut AMDMMIO::com2();
     p0.init().unwrap();
     p0.pwrite(b"Welcome to oreboot - com2\r\n", 0).unwrap();
-    let s = &mut [debug as &mut dyn Driver, uart0 as &mut dyn Driver, p0 as &mut dyn Driver];
+    let s = &mut [uart0 as &mut dyn Driver, p0 as &mut dyn Driver];
     let console = &mut DoD::new(s);
 
     // todo: this should do the cpu init.

--- a/src/mainboard/amd/romecrb/src/main.rs
+++ b/src/mainboard/amd/romecrb/src/main.rs
@@ -631,8 +631,9 @@ fn start_bootstrap_core(fdt_address: usize) -> ! {
 #[no_mangle]
 pub extern "C" fn _start(fdt_address: usize) -> ! {
     // See <https://developer.amd.com/resources/epyc-resources/epyc-specifications/>, "Processor Programming Reference (PPR) for Family 17h Model 31h, Revision B0 Processors"
-    let apic_base = unsafe { Msr::new(0x1b).read() };
-    if apic_base & (1 << 8) != 0 {
+    let apic_base = unsafe { Msr::new(0x1b).read() }; // Note: This MSR is per-thread
+    let bootstrap_core = apic_base & (1 << 8) != 0;
+    if bootstrap_core {
         start_bootstrap_core(fdt_address);
     } else {
         // See coreboot:src/cpu/x86/smm/smihandler.c function "nodeid".

--- a/src/mainboard/amd/romecrb/src/main.rs
+++ b/src/mainboard/amd/romecrb/src/main.rs
@@ -272,25 +272,7 @@ fn cpu_init<'a>(w: &mut impl core::fmt::Write, soc: &'a mut soc::SOC) -> Result<
     }
 }
 
-#[no_mangle]
-pub extern "C" fn _start(fdt_address: usize) -> ! {
-    // See <https://developer.amd.com/resources/epyc-resources/epyc-specifications/>, "Processor Programming Reference (PPR) for Family 17h Model 31h, Revision B0 Processors"
-    let apic_base = unsafe { Msr::new(0x1b).read() };
-    if apic_base & (1 << 8) == 0 {
-        // not bootstrap core
-        // See coreboot:src/cpu/x86/smm/smihandler.c function "nodeid".
-        // APICx020: bits 31...24 (8 bits): APIC_ID; APIC defaults to 0xFEE0_0000
-        let apic_id = (peek32(0xFEE0_0020) >> 24) as u8;
-
-        let post = &mut IOPort;
-        let mut p: [u8; 1] = [0; 1];
-        p[0] = apic_id;
-        post.pwrite(&p, 0x80).unwrap();
-        loop {
-            arch::halt();
-        }
-    }
-
+fn start_bootstrap_core(fdt_address: usize) -> ! {
     let m = &mut MainBoard::new();
     m.init().unwrap();
     let io = &mut IOPort;
@@ -584,9 +566,9 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
         //let v = rdmsr(0xc001_1004);
         //write!(w, "c001_1004 is {:x} and APIC is bit {:x}\r\n", v, 1 << 9).unwrap();
     }
-    unsafe {
-        write!(w, "0x1b is {:x} \r\n", apic_base).unwrap();
-    }
+    // unsafe {
+    //    write!(w, "0x1b is {:x} \r\n", apic_base).unwrap();
+    //}
     p[0] = p[0] + 1;
     let payload = &mut BzImage {
         low_mem_size: 0x80000000,
@@ -644,6 +626,27 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     post.pwrite(&p, 0x80).unwrap();
     p[0] = p[0] + 1;
     arch::halt()
+}
+
+#[no_mangle]
+pub extern "C" fn _start(fdt_address: usize) -> ! {
+    // See <https://developer.amd.com/resources/epyc-resources/epyc-specifications/>, "Processor Programming Reference (PPR) for Family 17h Model 31h, Revision B0 Processors"
+    let apic_base = unsafe { Msr::new(0x1b).read() };
+    if apic_base & (1 << 8) != 0 {
+        start_bootstrap_core(fdt_address);
+    } else {
+        // See coreboot:src/cpu/x86/smm/smihandler.c function "nodeid".
+        // APICx020: bits 31...24 (8 bits): APIC_ID; APIC defaults to 0xFEE0_0000
+        let apic_id = (peek32(0xFEE0_0020) >> 24) as u8;
+
+        let post = &mut IOPort;
+        let mut p: [u8; 1] = [0x33; 1];
+        p[0] = apic_id;
+        post.pwrite(&p, 0x80).unwrap();
+        loop {
+            arch::halt();
+        }
+    }
 }
 
 #[panic_handler]

--- a/src/mainboard/amd/romecrb/start.S
+++ b/src/mainboard/amd/romecrb/start.S
@@ -135,7 +135,7 @@ outb	%al, $0x80
 	subw	%ax, %bx
 	lidt	%cs:(%bx)
 */
-	movl	$0xffffffc8, %ebx
+	movl	$0xffffffe8, %ebx
 	// Leave it hand assembled. gas will NOT do the right thing.
 	//lgdtl	%cs:(%bx)
 	.byte 0x66, 0x2E, 0x0F, 0x01, 0x17
@@ -162,6 +162,16 @@ protected:
 	movw	%ax, %fs
 	movw	%ax, %gs
 
+	// See coreboot:src/cpu/x86/smm/smihandler.c function "nodeid".
+	// APICx020: bits 31...24 (8 bits): APIC_ID; APIC defaults to 0xFEE0_0000
+	movl ($0xFEE0_0020), %ebx
+	shr $24, %ebx
+
+	mov %ebx, %esp
+	shl $13, %esp
+	add $0x2000, %esp
+	// Note: All the stacks are below address 0x20_0000
+
 	/* Restore the BIST value to %eax */
 	movl	%ebp, %eax
 	jmp 1f
@@ -170,7 +180,7 @@ protected:
 	 * The gdt is defined in entry32.inc, it has a 4 Gb code segment
 	 * at 0x08, and a 4 GB data segment at 0x10;
 	 */
-.org 0xFFc8
+.org 0xFFe8
 9:
 .globl gdtptr16
 gdtptr16:
@@ -186,6 +196,6 @@ gdtptr16:
 //	nop
 	nop
 	outb %al, $0x80
-	movl $0x2000, %esp
+
 	push $0x76f08000
 	ret

--- a/src/mainboard/amd/romecrb/start.S
+++ b/src/mainboard/amd/romecrb/start.S
@@ -168,9 +168,9 @@ protected:
 	shr $24, %ebx
 
 	mov %ebx, %esp
-	shl $13, %esp
-	add $0x2000, %esp
-	// Note: All the stacks are below address 0x20_0000
+	inc %esp
+	shl $15, %esp
+	// Note: All the stacks are below address 0x80_0000
 
 	/* Restore the BIST value to %eax */
 	movl	%ebp, %eax

--- a/src/mainboard/amd/romecrb/start.S
+++ b/src/mainboard/amd/romecrb/start.S
@@ -162,6 +162,12 @@ protected:
 	movw	%ax, %fs
 	movw	%ax, %gs
 
+	// Enable APIC (in xAPIC mode) so we can read out the APIC_ID from MMIO at $0xFEE0_0020
+	movl   $0x1b, %ecx
+	rdmsr
+	orl $0x800, %eax
+	wrmsr
+
 	// See coreboot:src/cpu/x86/smm/smihandler.c function "nodeid".
 	// APICx020: bits 31...24 (8 bits): APIC_ID; APIC defaults to 0xFEE0_0000
 	movl ($0xFEE0_0020), %ebx

--- a/src/mainboard/amd/romecrb/start.S
+++ b/src/mainboard/amd/romecrb/start.S
@@ -178,6 +178,9 @@ protected:
 	shl $15, %esp
 	// Note: All the stacks are below address 0x80_0000
 
+        // Push the APIC_ID on the stack as a little debugging helper
+        push %ebx
+
 	/* Restore the BIST value to %eax */
 	movl	%ebp, %eax
 	jmp 1f


### PR DESCRIPTION
This makes `start.S` set up different stacks for different cores and threads.

It has been successfully tested.

The actual mechanism to enable physical cores in the first place is being documented by Paul, but he is not done yet (i.e. that part is not in this pull request). Therefore, this cannot be tested right now by people without AGESA access.

Note that it is my intention to have oreboot still only run on the bootstrap core. The other cores are only enabled so (1) Linux can use them and (2) we can set up MSRs for them.

The idea is that `_start` would check the `BSP` flag and then would `hlt` if it's not the bootstrap core--only for it to be later woken up for a short while by an interrupt (NMI, IPI or similar).

Note: TODO (later): adapt call `setup_acpi_tables(w, ?, <number of cores>)`