### PR TITLE
Rome: setup_acpi_tables: Autodetect the number of cores.

### DIFF
--- a/src/mainboard/amd/romecrb/src/main.rs
+++ b/src/mainboard/amd/romecrb/src/main.rs
@@ -597,7 +597,7 @@ fn start_bootstrap_core(fdt_address: usize) -> ! {
     }
 
     write!(w, "Write acpi tables\r\n").unwrap();
-    setup_acpi_tables(w, 0xf0000, 1);
+    setup_acpi_tables(w, 0xf_0000); // Note: Linux needs to be compiled with CONFIG_ACPI_LEGACY_TABLES_LOOKUP enabled for that address to be used.
     write!(w, "Wrote bios tables, entering debug\r\n").unwrap();
     consdebug(w);
     if false {


### PR DESCRIPTION
Autodetect the number of cores and use it to set up the ACPI tables.