### PR TITLE
Clean up UART handling on Rome

### DIFF
--- a/src/mainboard/amd/romecrb/src/mainboard.rs
+++ b/src/mainboard/amd/romecrb/src/mainboard.rs
@@ -24,7 +24,7 @@ use core::ops::Not;
 use core::ptr;
 use model::*;
 use smn::smn_write;
-use uart::amdmmio::AMDMMIO;
+use uart::amdmmio::UART;
 use uart::debug_port::DebugPort;
 use uart::i8250::I8250;
 use vcell::VolatileCell;
@@ -96,12 +96,12 @@ where
 pub struct MainBoard {
     com1: I8250<IOPort>,
     debug: DebugPort<IOPort>,
-    uart0: AMDMMIO,
+    uart0: UART,
 }
 
 impl MainBoard {
     pub fn new() -> MainBoard {
-        Self { com1: I8250::new(0x3f8, 0, IOPort {}), debug: DebugPort::new(0x80, IOPort {}), uart0: AMDMMIO::com1() }
+        Self { com1: I8250::new(0x3f8, 0, IOPort {}), debug: DebugPort::new(0x80, IOPort {}), uart0: UART::uart0() }
     }
     pub fn text_output_drivers(&mut self) -> [&mut dyn Driver; 3] {
         [&mut self.com1, &mut self.debug, &mut self.uart0]

--- a/src/mainboard/amd/romecrb/src/mainboard.rs
+++ b/src/mainboard/amd/romecrb/src/mainboard.rs
@@ -96,15 +96,15 @@ where
 pub struct MainBoard {
     com1: I8250<IOPort>,
     debug: DebugPort<IOPort>,
-    uart1: AMDMMIO,
+    uart0: AMDMMIO,
 }
 
 impl MainBoard {
     pub fn new() -> MainBoard {
-        Self { com1: I8250::new(0x3f8, 0, IOPort {}), debug: DebugPort::new(0x80, IOPort {}), uart1: AMDMMIO::com2() }
+        Self { com1: I8250::new(0x3f8, 0, IOPort {}), debug: DebugPort::new(0x80, IOPort {}), uart0: AMDMMIO::com1() }
     }
     pub fn text_output_drivers(&mut self) -> [&mut dyn Driver; 3] {
-        [&mut self.com1, &mut self.debug, &mut self.uart1]
+        [&mut self.com1, &mut self.debug, &mut self.uart0]
     }
 }
 

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -14,7 +14,7 @@ use model::Driver;
 use print;
 use raw_cpuid::CpuId;
 use soc::soc_init;
-// use uart::amdmmio::AMDMMIO;
+// use uart::amdmmio::UART;
 use uart::debug_port::DebugPort;
 use uart::i8250::I8250;
 mod mainboard;


### PR DESCRIPTION
This patch series cleans up the naming of the AMD UARTs in oreboot (to make it less confusing) and then makes romecrb use both UARTs again.
