### PR TITLE
Factor out common parts from AMD mainboard "romecrb"

### DIFF
--- a/src/drivers/uart/src/debug_port.rs
+++ b/src/drivers/uart/src/debug_port.rs
@@ -1,19 +1,19 @@
 use model::{Driver, Result};
 use timer::hpet::HPET;
 
-pub struct DebugPort<'a> {
+pub struct DebugPort<D: Driver> {
     address: usize,
-    d: &'a mut dyn Driver,
+    d: D,
     timer: HPET,
 }
 
-impl<'a> DebugPort<'a> {
-    pub fn new(address: usize, d: &'a mut dyn Driver) -> DebugPort<'a> {
+impl<D: Driver> DebugPort<D> {
+    pub fn new(address: usize, d: D) -> DebugPort<D> {
         DebugPort { address, d, timer: HPET::hpet() }
     }
 }
 
-impl<'a> Driver for DebugPort<'a> {
+impl<D: Driver> Driver for DebugPort<D> {
     // Nothing to set up here
     fn init(&mut self) -> Result<()> {
         Ok(())

--- a/src/drivers/uart/src/i8250.rs
+++ b/src/drivers/uart/src/i8250.rs
@@ -1,13 +1,13 @@
 use model::*;
 
-pub struct I8250<'a> {
+pub struct I8250<D: Driver> {
     base: usize,
     _baud: u32,
-    d: &'a mut dyn Driver,
+    d: D,
 }
 
-impl<'a> I8250<'a> {
-    pub fn new(base: usize, _baud: u32, d: &'a mut dyn Driver) -> I8250<'a> {
+impl<'a, D: Driver> I8250<D> {
+    pub fn new(base: usize, _baud: u32, d: D) -> I8250<D> {
         I8250 { base, _baud, d }
     }
 
@@ -26,7 +26,7 @@ impl<'a> I8250<'a> {
     }
 }
 #[allow(dead_code)]
-impl<'a> Driver for I8250<'a> {
+impl<D: Driver> Driver for I8250<D> {
     // TODO: properly use the register crate.
     fn init(&mut self) -> Result<()> {
         const DLL: usize = 0x00; // Divisor Latch Low Byte               RW
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn uart_driver_disables_fifos() {
         let mut vec = Vec::<u8, heapless::consts::U8>::new();
-        let port = &mut MockPort::new(&mut vec);
+        let port = MockPort::new(&mut vec);
         let test_uart = &mut I8250::new(0, 0, port);
         test_uart.init().unwrap();
 
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn uart_driver_sets_wordlength_and_stopbit() {
         let mut vec = Vec::<u8, heapless::consts::U8>::new();
-        let port = &mut MockPort::new(&mut vec);
+        let port = MockPort::new(&mut vec);
         let test_uart = &mut I8250::new(0, 0, port);
         test_uart.init().unwrap();
 

--- a/src/lib/print/src/lib.rs
+++ b/src/lib/print/src/lib.rs
@@ -9,11 +9,32 @@ pub struct WriteTo<'a, D: Driver> {
 
 impl<'a, D: Driver> WriteTo<'a, D> {
     pub fn new(drv: &'a mut D) -> Self {
-        WriteTo { drv }
+        Self { drv }
     }
 }
 
 impl<'a, D: Driver> fmt::Write for WriteTo<'a, D> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        match self.drv.pwrite(s.as_bytes(), 0) {
+            Err(_) => Err(fmt::Error),
+            _ => Ok(()),
+        }
+    }
+}
+
+//
+
+pub struct WriteToDyn<'a> {
+    drv: &'a mut dyn Driver,
+}
+
+impl<'a> WriteToDyn<'a> {
+    pub fn new(drv: &'a mut dyn Driver) -> Self {
+        Self { drv }
+    }
+}
+
+impl<'a> fmt::Write for WriteToDyn<'a> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         match self.drv.pwrite(s.as_bytes(), 0) {
             Err(_) => Err(fmt::Error),

--- a/src/mainboard/aaeon/upsquared/src/main.rs
+++ b/src/mainboard/aaeon/upsquared/src/main.rs
@@ -17,8 +17,7 @@ global_asm!(include_str!("../../../../arch/x86/x86_64/src/bootblock.S"));
 
 #[no_mangle]
 pub extern "C" fn _start(_fdt_address: usize) -> ! {
-    let io = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     // Note: on real hardware, use port 0x80 instead for "POST" output
     let debug_io = &mut IOPort;
     let debug = &mut DebugPort::new(0xe9, debug_io);
@@ -44,8 +43,7 @@ pub extern "C" fn _start(_fdt_address: usize) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     // Assume that uart0.init() has already been called before the panic.
-    let io = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     let w = &mut print::WriteTo::new(uart0);
     // Printing in the panic handler is best-effort because we really don't want to invoke the panic
     // handler from inside itself.

--- a/src/mainboard/aaeon/upsquared/src/main.rs
+++ b/src/mainboard/aaeon/upsquared/src/main.rs
@@ -19,8 +19,7 @@ global_asm!(include_str!("../../../../arch/x86/x86_64/src/bootblock.S"));
 pub extern "C" fn _start(_fdt_address: usize) -> ! {
     let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     // Note: on real hardware, use port 0x80 instead for "POST" output
-    let debug_io = &mut IOPort;
-    let debug = &mut DebugPort::new(0xe9, debug_io);
+    let debug = &mut DebugPort::new(0xe9, IOPort {});
     uart0.init().unwrap();
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
     debug.init().unwrap();

--- a/src/mainboard/amd/romecrb/src/main.rs
+++ b/src/mainboard/amd/romecrb/src/main.rs
@@ -24,8 +24,8 @@ mod msr;
 use msr::msrs;
 mod c00;
 use c00::c00;
-use x86_64::registers::model_specific::Msr;
 use wrappers::DoD;
+use x86_64::registers::model_specific::Msr;
 
 use core::ptr;
 

--- a/src/mainboard/amd/romecrb/src/main.rs
+++ b/src/mainboard/amd/romecrb/src/main.rs
@@ -120,9 +120,8 @@ fn cpu_init<'a>(w: &mut impl core::fmt::Write, soc: &'a mut soc::SOC) -> Result<
 fn start_bootstrap_core(fdt_address: usize) -> ! {
     let m = &mut MainBoard::new();
     m.init().unwrap();
-    let io = &mut IOPort;
     let post = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     uart0.init().unwrap();
     //let debug_io = &mut IOPort;
     //let debug = &mut DebugPort::new(0x80, debug_io);
@@ -475,8 +474,7 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     // Assume that uart0.init() has already been called before the panic.
-    let io = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     let w = &mut print::WriteTo::new(uart0);
     // Printing in the panic handler is best-effort because we really don't want to invoke the panic
     // handler from inside itself.

--- a/src/mainboard/amd/romecrb/src/mainboard.rs
+++ b/src/mainboard/amd/romecrb/src/mainboard.rs
@@ -16,6 +16,7 @@
 
 #![allow(non_upper_case_globals)]
 
+use arch::ioport::IOPort;
 use clock::ClockNode;
 use core::ops::BitAnd;
 use core::ops::BitOr;
@@ -23,6 +24,9 @@ use core::ops::Not;
 use core::ptr;
 use model::*;
 use smn::smn_write;
+use uart::amdmmio::AMDMMIO;
+use uart::debug_port::DebugPort;
+use uart::i8250::I8250;
 use vcell::VolatileCell;
 use x86_64::registers::model_specific::Msr;
 
@@ -89,11 +93,18 @@ where
 }
 
 // WIP: mainboard driver. I mean the concept is a WIP.
-pub struct MainBoard {}
+pub struct MainBoard {
+    com1: I8250<IOPort>,
+    debug: DebugPort<IOPort>,
+    uart1: AMDMMIO,
+}
 
 impl MainBoard {
     pub fn new() -> MainBoard {
-        MainBoard {}
+        Self { com1: I8250::new(0x3f8, 0, IOPort {}), debug: DebugPort::new(0x80, IOPort {}), uart1: AMDMMIO::com2() }
+    }
+    pub fn text_output_drivers(&mut self) -> [&mut dyn Driver; 3] {
+        [&mut self.com1, &mut self.debug, &mut self.uart1]
     }
 }
 

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -256,8 +256,7 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     m.init().unwrap();
     let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     uart0.init().unwrap();
-    //let debug_io = &mut IOPort;
-    //let debug = &mut DebugPort::new(0x80, debug_io);
+    //let debug = &mut DebugPort::new(0x80, IOPort {});
     uart0.init().unwrap();
     uart0.pwrite(b"Welcome to oreboot - UART0\r\n", 0).unwrap();
     //debug.init().unwrap();

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -167,8 +167,7 @@ fn consdebug(w: &mut impl core::fmt::Write) -> () {
     let mut done: bool = false;
     let newline: [u8; 2] = [10, 13];
     while done == false {
-        let io = &mut IOPort;
-        let uart0 = &mut I8250::new(0x3f8, 0, io);
+        let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
         let mut line: Vec<u8, U16> = Vec::new();
         loop {
             let mut c: [u8; 1] = [12; 1];
@@ -255,8 +254,7 @@ fn cpu_init(w: &mut impl core::fmt::Write) -> Result<(), &str> {
 pub extern "C" fn _start(fdt_address: usize) -> ! {
     let m = &mut MainBoard::new();
     m.init().unwrap();
-    let io = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     uart0.init().unwrap();
     //let debug_io = &mut IOPort;
     //let debug = &mut DebugPort::new(0x80, debug_io);
@@ -340,8 +338,7 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     // Assume that uart0.init() has already been called before the panic.
-    let io = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     let w = &mut print::WriteTo::new(uart0);
     // Printing in the panic handler is best-effort because we really don't want to invoke the panic
     // handler from inside itself.

--- a/src/mainboard/emulation/qemu-fsp/src/main.rs
+++ b/src/mainboard/emulation/qemu-fsp/src/main.rs
@@ -22,8 +22,7 @@ pub extern "C" fn _start(_fdt_address: usize) -> ! {
     // FSP has some SSE instructions.
     arch::enable_sse();
 
-    let io = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     uart0.init().unwrap();
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
 
@@ -42,8 +41,7 @@ pub extern "C" fn _start(_fdt_address: usize) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     // Assume that uart0.init() has already been called before the panic.
-    let io = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     let w = &mut print::WriteTo::new(uart0);
     // Printing in the panic handler is best-effort because we really don't want to invoke the panic
     // handler from inside itself.

--- a/src/mainboard/emulation/qemu-q35/src/main.rs
+++ b/src/mainboard/emulation/qemu-q35/src/main.rs
@@ -17,8 +17,7 @@ global_asm!(include_str!("../../../../arch/x86/x86_64/src/bootblock_nomem.S"));
 
 #[no_mangle]
 pub extern "C" fn _start(fdt_address: usize) -> ! {
-    let io = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     // Note: on real hardware, use port 0x80 instead for "POST" output
     let debugIO = &mut IOPort;
     let debug = &mut DebugPort::new(0xe9, debugIO);
@@ -44,8 +43,7 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     // Assume that uart0.init() has already been called before the panic.
-    let io = &mut IOPort;
-    let uart0 = &mut I8250::new(0x3f8, 0, io);
+    let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     let w = &mut print::WriteTo::new(uart0);
     // Printing in the panic handler is best-effort because we really don't want to invoke the panic
     // handler from inside itself.

--- a/src/mainboard/emulation/qemu-q35/src/main.rs
+++ b/src/mainboard/emulation/qemu-q35/src/main.rs
@@ -19,8 +19,7 @@ global_asm!(include_str!("../../../../arch/x86/x86_64/src/bootblock_nomem.S"));
 pub extern "C" fn _start(fdt_address: usize) -> ! {
     let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     // Note: on real hardware, use port 0x80 instead for "POST" output
-    let debugIO = &mut IOPort;
-    let debug = &mut DebugPort::new(0xe9, debugIO);
+    let debug = &mut DebugPort::new(0xe9, IOPort {});
     uart0.init().unwrap();
     uart0.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
     debug.init().unwrap();

--- a/src/soc/amd/common/boot/src/lib.rs
+++ b/src/soc/amd/common/boot/src/lib.rs
@@ -139,8 +139,7 @@ fn consdebug(w: &mut impl core::fmt::Write) {
     let mut done: bool = false;
     let newline: [u8; 2] = [10, 13];
     while !done {
-        let mut io = IOPort {};
-        let uart0 = &mut I8250::new(0x3f8, 0, &mut io);
+        let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
         let mut line: Vec<u8, U16> = Vec::new();
         loop {
             let mut c: [u8; 1] = [12; 1];

--- a/src/soc/amd/common/boot/src/lib.rs
+++ b/src/soc/amd/common/boot/src/lib.rs
@@ -14,8 +14,6 @@ use heapless::consts::*;
 use heapless::Vec;
 
 use core::ptr;
-// Until we are done hacking on this, use our private copy.
-// Plan to copy it back later.
 global_asm!(include_str!("bootblock.S"));
 
 fn poke32(a: u32, v: u32) {


### PR DESCRIPTION
This patchset factors out more common parts from AMD mainboard "romecrb".

First, make I8250 and DebugPort actually own their respective IOPorts.

Then, add WriteToDyn to print as an extra fmt::Write implementation that is implemented on a `dyn Driver` rather than a on concrete implementation of `Driver`.

Then, make the `romecrb` mainboard return a list of possible text output drivers.
Use that in `main.rs` in order to find out which text output drivers to use.

Last, clean out obsolete comment about custom bootblock.S from src/soc/amd/common/boot/src/lib.rs .