### PR TITLE
Rome: Init all the text output drivers automatically.

### DIFF
--- a/src/mainboard/amd/romecrb/src/mainboard.rs
+++ b/src/mainboard/amd/romecrb/src/mainboard.rs
@@ -182,6 +182,10 @@ impl Driver for MainBoard {
             // IOHC::IOAPIC_BASE_ADDR_LO
             smn_write(0x13B1_02f0, 0xFEC0_0001);
 
+            for driver in self.text_output_drivers().iter_mut() {
+                driver.init()?;
+            }
+
             Ok(())
         }
     }


### PR DESCRIPTION
After the big refactoring, I forgot to call the Driver::init for all the text output drivers. That made the serial ports not print any output on the BMC serial on real hardware.

This patch adds it again.