### PR TITLE
AMD Bootblock: Fix up.

### DIFF
--- a/src/soc/amd/common/boot/src/bootblock.S
+++ b/src/soc/amd/common/boot/src/bootblock.S
@@ -66,14 +66,19 @@ gdt:
 #define CODE32 0x18
 	/* selgdt 0x18, flat code segment */
 	.word	0xffff, 0x0000
-	.byte	0x00, 0x9b, 0xcf, 0x00 /* G=1 and 0x0f, So we get 4Gbytes
-#define DAT32 0x20					  for limit */
+	.byte	0x00, 0x9b, 0xcf, 0x00 /* G=1 and 0x0f, So we get 4Gbytes for limit */
+#define DAT32 0x20
 	/* selgdt 0x20,flat data segment */
 	.word	0xffff, 0x0000
 	.byte	0x00, 0x93, 0xcf, 0x00
 #define LM 0x28
 	/* selgdt 0x28, long mode code segment. */
-	.quad	0x0020980000000000		/* Long mode CS */
+	.word 0x0000 /* segment limit lo */
+	.word 0x0000 /* base address lo */
+	.byte 0x00 /* base address mid */
+	.byte 0x98 /* P=1 DPL=00 S=1 Type=1000 */
+	.byte 0x20 /* segment limit hi; so limit = 0x200000 (8 GiB with 4 KiB pages) */
+	.byte 0x00 /* base address hi */
 
 gdt_end:
 3:

--- a/src/soc/amd/common/boot/src/bootblock.S
+++ b/src/soc/amd/common/boot/src/bootblock.S
@@ -90,8 +90,9 @@ gdt_end:
 	// The low 4 bits of %eax are 3.
 	// the gdt pointer is aligned to 16.
 	// Set the low 4-bits of offset to 16.
-	andb $0xf0, %al
-	orb $0x10, %al
+	addl $0x0f, %eax
+	andl $0xfffffff0, %eax
+	//mov $gdtptr, %eax
 	pushl %eax
 	// Adjust the gdt pointer for where we are.
 	addl	$8, %eax

--- a/src/soc/amd/common/boot/src/bootblock.S
+++ b/src/soc/amd/common/boot/src/bootblock.S
@@ -175,8 +175,8 @@ __protected_start_no_load_segs:
 	// Set a pointer to the page table pages in %cr3.
 	// We can use cr3 as a scratch register here;
 	// its value won't matter until we set PG in CR0 below.
-	movl $pml4, %esp
-	movl %esp, %cr3
+	movl $pml4, %eax
+	movl %eax, %cr3
 
 	// Now for the big fun: Long Mode.
 	// Once again we put the data structures inline in this


### PR DESCRIPTION
`bootblock.S` had trashed %esp that `start.S` meticiously set up.

This patch rectifies that.

Also, clean up some comments and also make the rounding-up more resilient.