### PR TITLE
AMD Rome: Remove duplicate LDN setup.

### DIFF
--- a/src/mainboard/amd/romecrb/src/main.rs
+++ b/src/mainboard/amd/romecrb/src/main.rs
@@ -415,14 +415,9 @@ fn start_bootstrap_core(fdt_address: usize) -> ! {
         msrs(w);
     }
     c00(w);
-    write!(w, "LDN is {:x}\r\n", peek32(0xfee000d0)).unwrap();
-    poke32(0xfee000d0, 0x1000000);
-    write!(w, "LDN is {:x}\r\n", peek32(0xfee000d0)).unwrap();
-    write!(w, "loading payload with fdt_address {}\r\n", fdt_address).unwrap();
 
     boot(w, fdt_address);
 
-    write!(w, "Unexpected return from payload\r\n").unwrap();
     arch::halt()
 }
 

--- a/src/mainboard/amd/romecrb/src/main.rs
+++ b/src/mainboard/amd/romecrb/src/main.rs
@@ -35,12 +35,6 @@ fn poke32(a: u32, v: u32) -> () {
         ptr::write_volatile(y, v);
     }
 }
-fn poke8(a: u32, v: u8) -> () {
-    let y = a as *mut u8;
-    unsafe {
-        ptr::write_volatile(y, v);
-    }
-}
 
 fn peek32(a: u32) -> u32 {
     let y = a as *const u32;


### PR DESCRIPTION
This setup is already done in src/amd/common/boot, so don't do it again.