### PR TITLE
AMD Romecrb: Don't use port 0x80 as text output destination anymore.

### DIFF
--- a/src/mainboard/amd/romecrb/src/mainboard.rs
+++ b/src/mainboard/amd/romecrb/src/mainboard.rs
@@ -102,8 +102,8 @@ impl MainBoard {
     pub fn new() -> MainBoard {
         Self { com1: I8250::new(0x3f8, 0, IOPort {}), debug: DebugPort::new(0x80, IOPort {}), uart0: UART::uart0() }
     }
-    pub fn text_output_drivers(&mut self) -> [&mut dyn Driver; 3] {
-        [&mut self.com1, &mut self.debug, &mut self.uart0]
+    pub fn text_output_drivers(&mut self) -> [&mut dyn Driver; 2] {
+        [&mut self.com1, &mut self.uart0]
     }
 }
 


### PR DESCRIPTION
Since our serial ports work well now, stop printing to port 0x80 by default on amd romecrb.