### PR TITLE
a300 picasso acpi debug

### DIFF
--- a/src/arch/x86/x86_64/src/acpi.rs
+++ b/src/arch/x86/x86_64/src/acpi.rs
@@ -44,7 +44,16 @@ pub const ACPI_TABLE_HEADER_CHECKSUM_OFFSET: usize = 9;
 
 impl AcpiTableHeader {
     pub fn new() -> Self {
-        AcpiTableHeader { revision: 2, checksum: 0, oem_id: *b"OREORE", oem_table_id: *b"xOREBOOT", oem_revision: 0, asl_compiler_id: *b"RUST", asl_compiler_revision: 0, ..Default::default() }
+        AcpiTableHeader {
+            revision: 2,
+            checksum: 0,
+            oem_id: *b"OREORE",
+            oem_table_id: *b"xOREBOOT",
+            oem_revision: 0,
+            asl_compiler_id: *b"RUST",
+            asl_compiler_revision: 0,
+            ..Default::default()
+        }
     }
 }
 
@@ -67,62 +76,62 @@ pub struct AcpiGenericAddress {
 #[repr(packed)]
 #[derive(Default)]
 pub struct AcpiTableFadt {
-    pub header: AcpiTableHeader,                 /* Common ACPI table header */
-    pub facs: u32,                               /* 32-bit physical address of FACS */
-    pub dsdt: u32,                               /* 32-bit physical address of DSDT */
-    pub model: u8,                               /* System Interrupt Model (ACPI 1.0) - not used in ACPI 2.0+ */
-    pub preferred_profile: u8,                   /* Conveys preferred power management profile to OSPM. */
-    pub sci_interrupt: u16,                      /* System vector of SCI interrupt */
-    pub smi_command: u32,                        /* 32-bit Port address of SMI command port */
-    pub acpi_enable: u8,                         /* Value to write to SMI_CMD to enable ACPI */
-    pub acpi_disable: u8,                        /* Value to write to SMI_CMD to disable ACPI */
-    pub s4_bios_request: u8,                     /* Value to write to SMI_CMD to enter S4BIOS state */
-    pub pstate_control: u8,                      /* Processor performance state control */
-    pub pm1a_event_block: u32,                   /* 32-bit port address of Power Mgt 1a Event Reg Blk */
-    pub pm1b_event_block: u32,                   /* 32-bit port address of Power Mgt 1b Event Reg Blk */
-    pub pm1a_control_block: u32,                 /* 32-bit port address of Power Mgt 1a Control Reg Blk */
-    pub pm1b_control_block: u32,                 /* 32-bit port address of Power Mgt 1b Control Reg Blk */
-    pub pm2_control_block: u32,                  /* 32-bit port address of Power Mgt 2 Control Reg Blk */
-    pub pm_timer_block: u32,                     /* 32-bit port address of Power Mgt Timer Ctrl Reg Blk */
-    pub gpe0_block: u32,                         /* 32-bit port address of General Purpose Event 0 Reg Blk */
-    pub gpe1_block: u32,                         /* 32-bit port address of General Purpose Event 1 Reg Blk */
-    pub pm1_event_length: u8,                    /* Byte Length of ports at pm1x_event_block */
-    pub pm1_control_length: u8,                  /* Byte Length of ports at pm1x_control_block */
-    pub pm2_control_length: u8,                  /* Byte Length of ports at pm2_control_block */
-    pub pm_timer_length: u8,                     /* Byte Length of ports at pm_timer_block */
-    pub gpe0_block_length: u8,                   /* Byte Length of ports at gpe0_block */
-    pub gpe1_block_length: u8,                   /* Byte Length of ports at gpe1_block */
-    pub gpe1_base: u8,                           /* Offset in GPE number space where GPE1 events start */
-    pub cst_control: u8,                         /* Support for the _CST object and C-States change notification */
-    pub c2_latency: u16,                         /* Worst case HW latency to enter/exit C2 state */
-    pub c3_latency: u16,                         /* Worst case HW latency to enter/exit C3 state */
-    pub flush_size: u16,                         /* Processor memory cache line width, in bytes */
-    pub flush_stride: u16,                       /* Number of flush strides that need to be read */
-    pub duty_offset: u8,                         /* Processor duty cycle index in processor P_CNT reg */
-    pub duty_width: u8,                          /* Processor duty cycle value bit width in P_CNT register */
-    pub day_alarm: u8,                           /* Index to day-of-month alarm in RTC CMOS RAM */
-    pub month_alarm: u8,                         /* Index to month-of-year alarm in RTC CMOS RAM */
-    pub century: u8,                             /* Index to century in RTC CMOS RAM */
-    pub boot_flags: u16,                         /* IA-PC Boot Architecture Flags (see below for individual flags) */
-    pub reserved: u8,                            /* Reserved, must be zero */
-    pub flags: u32,                              /* Miscellaneous flag bits (see below for individual flags) */
-    pub reset_register: AcpiGenericAddress,      /* 64-bit address of the Reset register */
-    pub reset_value: u8,                         /* Value to write to the reset_register port to reset the system */
-    pub arm_boot_flags: u16,                     /* ARM-Specific Boot Flags (see below for individual flags) (ACPI 5.1) */
-    pub minor_revision: u8,                      /* FADT Minor Revision (ACPI 5.1) */
-    pub xfacs: u64,                              /* 64-bit physical address of FACS */
-    pub xdsdt: u64,                              /* 64-bit physical address of DSDT */
-    pub xpm1a_event_block: AcpiGenericAddress,   /* 64-bit Extended Power Mgt 1a Event Reg Blk address */
-    pub xpm1b_event_block: AcpiGenericAddress,   /* 64-bit Extended Power Mgt 1b Event Reg Blk address */
+    pub header: AcpiTableHeader,               /* Common ACPI table header */
+    pub facs: u32,                             /* 32-bit physical address of FACS */
+    pub dsdt: u32,                             /* 32-bit physical address of DSDT */
+    pub model: u8, /* System Interrupt Model (ACPI 1.0) - not used in ACPI 2.0+ */
+    pub preferred_profile: u8, /* Conveys preferred power management profile to OSPM. */
+    pub sci_interrupt: u16, /* System vector of SCI interrupt */
+    pub smi_command: u32, /* 32-bit Port address of SMI command port */
+    pub acpi_enable: u8, /* Value to write to SMI_CMD to enable ACPI */
+    pub acpi_disable: u8, /* Value to write to SMI_CMD to disable ACPI */
+    pub s4_bios_request: u8, /* Value to write to SMI_CMD to enter S4BIOS state */
+    pub pstate_control: u8, /* Processor performance state control */
+    pub pm1a_event_block: u32, /* 32-bit port address of Power Mgt 1a Event Reg Blk */
+    pub pm1b_event_block: u32, /* 32-bit port address of Power Mgt 1b Event Reg Blk */
+    pub pm1a_control_block: u32, /* 32-bit port address of Power Mgt 1a Control Reg Blk */
+    pub pm1b_control_block: u32, /* 32-bit port address of Power Mgt 1b Control Reg Blk */
+    pub pm2_control_block: u32, /* 32-bit port address of Power Mgt 2 Control Reg Blk */
+    pub pm_timer_block: u32, /* 32-bit port address of Power Mgt Timer Ctrl Reg Blk */
+    pub gpe0_block: u32, /* 32-bit port address of General Purpose Event 0 Reg Blk */
+    pub gpe1_block: u32, /* 32-bit port address of General Purpose Event 1 Reg Blk */
+    pub pm1_event_length: u8, /* Byte Length of ports at pm1x_event_block */
+    pub pm1_control_length: u8, /* Byte Length of ports at pm1x_control_block */
+    pub pm2_control_length: u8, /* Byte Length of ports at pm2_control_block */
+    pub pm_timer_length: u8, /* Byte Length of ports at pm_timer_block */
+    pub gpe0_block_length: u8, /* Byte Length of ports at gpe0_block */
+    pub gpe1_block_length: u8, /* Byte Length of ports at gpe1_block */
+    pub gpe1_base: u8, /* Offset in GPE number space where GPE1 events start */
+    pub cst_control: u8, /* Support for the _CST object and C-States change notification */
+    pub c2_latency: u16, /* Worst case HW latency to enter/exit C2 state */
+    pub c3_latency: u16, /* Worst case HW latency to enter/exit C3 state */
+    pub flush_size: u16, /* Processor memory cache line width, in bytes */
+    pub flush_stride: u16, /* Number of flush strides that need to be read */
+    pub duty_offset: u8, /* Processor duty cycle index in processor P_CNT reg */
+    pub duty_width: u8, /* Processor duty cycle value bit width in P_CNT register */
+    pub day_alarm: u8, /* Index to day-of-month alarm in RTC CMOS RAM */
+    pub month_alarm: u8, /* Index to month-of-year alarm in RTC CMOS RAM */
+    pub century: u8, /* Index to century in RTC CMOS RAM */
+    pub boot_flags: u16, /* IA-PC Boot Architecture Flags (see below for individual flags) */
+    pub reserved: u8, /* Reserved, must be zero */
+    pub flags: u32, /* Miscellaneous flag bits (see below for individual flags) */
+    pub reset_register: AcpiGenericAddress, /* 64-bit address of the Reset register */
+    pub reset_value: u8, /* Value to write to the reset_register port to reset the system */
+    pub arm_boot_flags: u16, /* ARM-Specific Boot Flags (see below for individual flags) (ACPI 5.1) */
+    pub minor_revision: u8,  /* FADT Minor Revision (ACPI 5.1) */
+    pub xfacs: u64,          /* 64-bit physical address of FACS */
+    pub xdsdt: u64,          /* 64-bit physical address of DSDT */
+    pub xpm1a_event_block: AcpiGenericAddress, /* 64-bit Extended Power Mgt 1a Event Reg Blk address */
+    pub xpm1b_event_block: AcpiGenericAddress, /* 64-bit Extended Power Mgt 1b Event Reg Blk address */
     pub xpm1a_control_block: AcpiGenericAddress, /* 64-bit Extended Power Mgt 1a Control Reg Blk address */
     pub xpm1b_control_block: AcpiGenericAddress, /* 64-bit Extended Power Mgt 1b Control Reg Blk address */
-    pub xpm2_control_block: AcpiGenericAddress,  /* 64-bit Extended Power Mgt 2 Control Reg Blk address */
-    pub xpm_timer_block: AcpiGenericAddress,     /* 64-bit Extended Power Mgt Timer Ctrl Reg Blk address */
-    pub xgpe0_block: AcpiGenericAddress,         /* 64-bit Extended General Purpose Event 0 Reg Blk address */
-    pub xgpe1_block: AcpiGenericAddress,         /* 64-bit Extended General Purpose Event 1 Reg Blk address */
-    pub sleep_control: AcpiGenericAddress,       /* 64-bit Sleep Control register (ACPI 5.0) */
-    pub sleep_status: AcpiGenericAddress,        /* 64-bit Sleep Status register (ACPI 5.0) */
-    pub hypervisor_id: u64,                      /* Hypervisor Vendor ID (ACPI 6.0) */
+    pub xpm2_control_block: AcpiGenericAddress, /* 64-bit Extended Power Mgt 2 Control Reg Blk address */
+    pub xpm_timer_block: AcpiGenericAddress, /* 64-bit Extended Power Mgt Timer Ctrl Reg Blk address */
+    pub xgpe0_block: AcpiGenericAddress, /* 64-bit Extended General Purpose Event 0 Reg Blk address */
+    pub xgpe1_block: AcpiGenericAddress, /* 64-bit Extended General Purpose Event 1 Reg Blk address */
+    pub sleep_control: AcpiGenericAddress, /* 64-bit Sleep Control register (ACPI 5.0) */
+    pub sleep_status: AcpiGenericAddress, /* 64-bit Sleep Status register (ACPI 5.0) */
+    pub hypervisor_id: u64,              /* Hypervisor Vendor ID (ACPI 6.0) */
 }
 
 #[repr(packed)]

--- a/src/mainboard/amd/romecrb/Cargo.toml
+++ b/src/mainboard/amd/romecrb/Cargo.toml
@@ -25,7 +25,7 @@ register = "0.3.2"
 static-ref = "0.1.1"
 postcard = "0.4.3"
 vcell = "0.1.2"
-x86_64 = "0.12.2"
+x86_64 = "0.14.0"
 
 [dependencies.uart]
 path = "../../../drivers/uart"

--- a/src/mainboard/asrock/a300m-stx/Cargo.lock
+++ b/src/mainboard/asrock/a300m-stx/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "console",
  "cpu",
  "heapless 0.4.4",
+ "lazy_static",
  "model",
  "payloads",
  "postcard",
@@ -175,6 +176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "model"
 version = "0.1.0"
 
@@ -303,6 +313,12 @@ dependencies = [
  "smn",
  "vcell",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"

--- a/src/mainboard/asrock/a300m-stx/Cargo.lock
+++ b/src/mainboard/asrock/a300m-stx/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "lazy_static",
  "model",
  "payloads",
+ "pci",
  "postcard",
  "print",
  "raw-cpuid",

--- a/src/mainboard/asrock/a300m-stx/Cargo.lock
+++ b/src/mainboard/asrock/a300m-stx/Cargo.lock
@@ -5,6 +5,7 @@ name = "a300m-stx"
 version = "0.1.0"
 dependencies = [
  "arch",
+ "boot",
  "clock",
  "console",
  "cpu",
@@ -60,6 +61,25 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "boot"
+version = "0.1.0"
+dependencies = [
+ "arch",
+ "clock",
+ "console",
+ "cpu",
+ "heapless 0.4.4",
+ "model",
+ "payloads",
+ "print",
+ "raw-cpuid",
+ "smn",
+ "uart",
+ "util",
+ "wrappers",
+]
 
 [[package]]
 name = "byteorder"

--- a/src/mainboard/asrock/a300m-stx/Cargo.lock
+++ b/src/mainboard/asrock/a300m-stx/Cargo.lock
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.12.2"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b4b42dbabe13b69023e1a1407d395f1a1a33df76e9a9efdbe303acc907e292"
+checksum = "021b49a4cb0a0d9490265cc169ca816014cbf61d3f3b75424815912977b81871"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/src/mainboard/asrock/a300m-stx/Cargo.toml
+++ b/src/mainboard/asrock/a300m-stx/Cargo.toml
@@ -23,7 +23,12 @@ register = "0.3.2"
 static-ref = "0.1.1"
 postcard = "0.4.3"
 vcell = "0.1.2"
+# TODO: 0.13.2 ?
 x86_64 = "0.12.2"
+
+[dependencies.lazy_static]
+version = "1.0"
+features = ["spin_no_std"]
 
 [dependencies.uart]
 path = "../../../drivers/uart"

--- a/src/mainboard/asrock/a300m-stx/Cargo.toml
+++ b/src/mainboard/asrock/a300m-stx/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 arch = { path = "../../../arch/x86/x86_64"}
+boot = { path = "../../../soc/amd/common/boot" }
 clock = { path = "../../../drivers/clock"}
 console = { path = "../../../console" }
 cpu = { path = "../../../cpu/amd" }

--- a/src/mainboard/asrock/a300m-stx/Cargo.toml
+++ b/src/mainboard/asrock/a300m-stx/Cargo.toml
@@ -24,7 +24,7 @@ register = "0.3.2"
 static-ref = "0.1.1"
 postcard = "0.4.3"
 vcell = "0.1.2"
-x86_64 = "0.14.0"
+x86_64 = "0.13.0"
 
 [dependencies.lazy_static]
 version = "1.0"

--- a/src/mainboard/asrock/a300m-stx/Cargo.toml
+++ b/src/mainboard/asrock/a300m-stx/Cargo.toml
@@ -11,6 +11,7 @@ clock = { path = "../../../drivers/clock"}
 console = { path = "../../../console" }
 cpu = { path = "../../../cpu/amd" }
 model = { path = "../../../drivers/model" }
+pci = { path = "../../../soc/amd/common/pci" }
 print = { path = "../../../lib/print" }
 payloads = { path = "../../../../payloads" }
 smn = { path = "../../../soc/amd/common/smn" }

--- a/src/mainboard/asrock/a300m-stx/Cargo.toml
+++ b/src/mainboard/asrock/a300m-stx/Cargo.toml
@@ -24,8 +24,7 @@ register = "0.3.2"
 static-ref = "0.1.1"
 postcard = "0.4.3"
 vcell = "0.1.2"
-# TODO: 0.13.2 ?
-x86_64 = "0.12.2"
+x86_64 = "0.14.0"
 
 [dependencies.lazy_static]
 version = "1.0"

--- a/src/mainboard/asrock/a300m-stx/rustfmt.toml
+++ b/src/mainboard/asrock/a300m-stx/rustfmt.toml
@@ -1,0 +1,5 @@
+overflow_delimited_expr = true
+unstable_features = true
+use_small_heuristics = "Max"
+force_multiline_blocks = true
+max_width = 100

--- a/src/mainboard/asrock/a300m-stx/src/acpi.rs
+++ b/src/mainboard/asrock/a300m-stx/src/acpi.rs
@@ -59,7 +59,6 @@ pub fn setup_acpi_tables(w: &mut impl core::fmt::Write, start: usize, cores: u32
     let rsdp_sig: u64 = read(rsdp_offset, 0);
     write!(w, "RSDP signature: {:x?}\r\n", rsdp_sig).unwrap();
 
-    /*
     write(
         w,
         gencsum(rsdp_offset, rsdp_offset + ACPI_RSDP_CHECKSUM_LENGTH),
@@ -97,7 +96,6 @@ pub fn setup_acpi_tables(w: &mut impl core::fmt::Write, start: usize, cores: u32
         ACPI_TABLE_HEADER_CHECKSUM_OFFSET,
     ); // XXX
     debug_assert_eq!(acpi_tb_checksum(xsdt_offset, xsdt_offset + xsdt_total_length), 0);
-    */
 
     /*
     const FADT_FLAGS: u32 = 0b0011_0000_0101_1010_0101;
@@ -180,7 +178,9 @@ pub fn setup_acpi_tables(w: &mut impl core::fmt::Write, start: usize, cores: u32
         ACPI_TABLE_HEADER_CHECKSUM_OFFSET,
     ); // XXX
     debug_assert_eq!(acpi_tb_checksum(fadt_offset, fadt_offset + size_of::<AcpiTableFadt>()), 0);
+    */
 
+    /*
     // facs - Firmware ACPI Control Structure
     let facs = AcpiTableFacs {
         signature: SIG_FACS,

--- a/src/mainboard/asrock/a300m-stx/src/bootblock.S
+++ b/src/mainboard/asrock/a300m-stx/src/bootblock.S
@@ -241,9 +241,9 @@ __protected_start_no_load_segs:
 	outb %al, $0x80
 	// Set a pointer to the page table pages in %cr3.
 	// We can use cr3 as a scratch register here;
-	// its value won't matter until we set PG in CR0 below.
-	movl $pml4, %esp
-	movl %esp, %cr3
+	// its value won't matter until we set PG in CR0 below
+	movl $pml4, %eax # don't use esp here? :)
+	movl %eax, %cr3
 
 	// Now for the big fun: Long Mode.
 	// Once again we put the data structures inline in this
@@ -374,7 +374,7 @@ Back32:
 	movw	%ax, %fs
 	movw	%ax, %gs
 
-	mov $0x2000, %esp
+	mov $0x10000, %esp # needz moar stack
 				// ; Disable Paging to get out of Long Mode
 	movb $0xb2, %al
 	outb %al, $0x80

--- a/src/mainboard/asrock/a300m-stx/src/interrupts.rs
+++ b/src/mainboard/asrock/a300m-stx/src/interrupts.rs
@@ -1,0 +1,56 @@
+#![feature(llvm_asm)]
+
+use lazy_static::lazy_static;
+use x86_64::structures::idt::InterruptDescriptorTable;
+use x86_64::structures::idt::InterruptStackFrame;
+
+fn outb(port: u16, val: u32) {
+    unsafe {
+        llvm_asm!("outl %eax, %dx" :: "{dx}"(port), "{al}"(val));
+    }
+}
+
+extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut InterruptStackFrame) {
+    unsafe {
+        outb(0x80, 0x11);
+    }
+    panic!("Exception: Breakpoint.\r\n{:#?}", stack_frame);
+}
+
+extern "x86-interrupt" fn double_fault_handler(
+    stack_frame: &mut InterruptStackFrame,
+    _error_code: u64,
+) -> ! {
+    panic!("Exception: Double fault.\r\n{:#?}", stack_frame);
+}
+
+extern "x86-interrupt" fn divide_error_handler(stack_frame: &mut InterruptStackFrame) {
+    panic!("NOOOOOOO\r\n");
+}
+
+extern "x86-interrupt" fn interrupt_handler(stack_frame: &mut InterruptStackFrame) {
+    panic!("Interrupt.\r\n{:#?}", stack_frame);
+}
+
+//lazy_static! {
+//    static ref IDT: InterruptDescriptorTable = {
+//        let mut idt = InterruptDescriptorTable::new();
+//        idt.breakpoint.set_handler_fn(breakpoint_handler);
+//        idt.double_fault.set_handler_fn(double_fault_handler);
+//        idt.divide_error.set_handler_fn(divide_error_handler);
+//        idt
+//    };
+//}
+
+pub fn init_idt() {
+    //    IDT.load();
+    unsafe {
+        let mut idt = 0x100000 as *mut InterruptDescriptorTable;
+        (*idt).breakpoint.set_handler_fn(breakpoint_handler);
+        (*idt).double_fault.set_handler_fn(double_fault_handler);
+        (*idt).divide_error.set_handler_fn(divide_error_handler);
+        (*idt).simd_floating_point.set_handler_fn(divide_error_handler);
+        (*idt)[32].set_handler_fn(interrupt_handler);
+        (*idt).load();
+    }
+}

--- a/src/mainboard/asrock/a300m-stx/src/interrupts.rs
+++ b/src/mainboard/asrock/a300m-stx/src/interrupts.rs
@@ -24,7 +24,11 @@ extern "x86-interrupt" fn double_fault_handler(
     panic!("Exception: Double fault.\r\n{:#?}", stack_frame);
 }
 
-extern "x86-interrupt" fn divide_error_handler(stack_frame: &mut InterruptStackFrame) {
+extern "x86-interrupt" fn boom_handler(stack_frame: &mut InterruptStackFrame, _error_code: u64) {
+    panic!("BOOOOOM!\r\n{:#?}", stack_frame);
+}
+
+extern "x86-interrupt" fn stack_handler(stack_frame: &mut InterruptStackFrame) {
     panic!("NOOOOOOO\r\n");
 }
 
@@ -48,8 +52,17 @@ pub fn init_idt() {
         let mut idt = 0x100000 as *mut InterruptDescriptorTable;
         (*idt).breakpoint.set_handler_fn(breakpoint_handler);
         (*idt).double_fault.set_handler_fn(double_fault_handler);
-        (*idt).divide_error.set_handler_fn(divide_error_handler);
-        (*idt).simd_floating_point.set_handler_fn(divide_error_handler);
+
+        (*idt).segment_not_present.set_handler_fn(boom_handler);
+        (*idt).stack_segment_fault.set_handler_fn(boom_handler);
+        (*idt).general_protection_fault.set_handler_fn(boom_handler);
+
+        (*idt).invalid_opcode.set_handler_fn(stack_handler);
+
+        (*idt).x87_floating_point.set_handler_fn(stack_handler);
+        // (*idt).simd_floating_point.set_handler_fn(stack_handler);
+        // (*idt).divide_error.set_handler_fn(stack_handler);
+
         (*idt)[32].set_handler_fn(interrupt_handler);
         (*idt).load();
     }

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -302,14 +302,14 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     }
 
     let payload = &mut BzImage {
-        low_mem_size: 0x80000000,
-        high_mem_start: 0x100000000,
+        low_mem_size: 0x8000_0000,
+        high_mem_start: 0x1_0000_0000,
         high_mem_size: 0,
         // TODO: get this from the FDT.
-        rom_base: 0xffc00000,
-        rom_size: 0x300000,
-        load: 0x01000000,
-        entry: 0x1000200,
+        rom_base: 0xffc0_0000,
+        rom_size: 0x30_0000,
+        load: 0x0100_0000,
+        entry: 0x100_0200,
     };
     if true {
         msrs(w);

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -293,7 +293,7 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
 
     // disable legacy interrupts
     // smnhack(w, 0x13F0_0004, 0x0010_0400u32);
-    smnhack(w, 0x13F0_0064, 0x0010_0400u32); // 847405
+    // smnhack(w, 0x13F0_0064, 0x0010_0400u32); // 847405
 
     // It is hard to say if we need to do this.
     if true {

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -336,7 +336,9 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     }
 
     write!(w, "Write acpi tables\r\n").unwrap();
-    setup_acpi_tables(w, 0xf0000, 1);
+    if (true) {
+        setup_acpi_tables(w, 0xf0000, 1);
+    }
     write!(w, "Wrote bios tables, entering debug\r\n").unwrap();
 
     if false {

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -14,6 +14,7 @@ use cpu::model::amd_model_id;
 use model::Driver;
 use print;
 use raw_cpuid::CpuId;
+use smn::{smn_read, smn_write};
 use soc::soc_init;
 // use uart::amdmmio::UART;
 use uart::debug_port::DebugPort;
@@ -207,6 +208,16 @@ fn consdebug(w: &mut impl core::fmt::Write) -> () {
     }
 }
 //global_asm!(include_str!("init.S"));
+fn smnhack(w: &mut impl core::fmt::Write, reg: u32, want: u32) -> () {
+    let got = smn_read(reg);
+    write!(w, "{:x}: got {:x}, want {:x}\r\n", reg, got, want).unwrap();
+    if got == want {
+        return;
+    }
+    smn_write(reg, want);
+    let got = smn_read(reg);
+    write!(w, "Try 2: {:x}: got {:x}, want {:x}\r\n", reg, got, want).unwrap();
+}
 
 fn cpu_init(w: &mut impl core::fmt::Write) -> Result<(), &str> {
     let cpuid = CpuId::new();

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -214,9 +214,9 @@ fn smnhack(w: &mut impl core::fmt::Write, reg: u32, want: u32) -> () {
     if got == want {
         return;
     }
-    smn_write(reg, want);
-    let got = smn_read(reg);
-    write!(w, "Try 2: {:x}: got {:x}, want {:x}\r\n", reg, got, want).unwrap();
+    // smn_write(reg, want);
+    // let got = smn_read(reg);
+    // write!(w, "Try 2: {:x}: got {:x}, want {:x}\r\n", reg, got, want).unwrap();
 }
 
 fn cpu_init(w: &mut impl core::fmt::Write) -> Result<(), &str> {
@@ -290,6 +290,10 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
         }
         write!(w, "Didn't explode :(\r\n").unwrap();
     }
+
+    // disable legacy interrupts
+    // smnhack(w, 0x13F0_0004, 0x0010_0400u32);
+    smnhack(w, 0x13F0_0064, 0x0010_0400u32); // 847405
 
     // It is hard to say if we need to do this.
     if true {

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -129,10 +129,6 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
         write!(w, "Didn't explode :(\r\n").unwrap();
     }
 
-    // disable legacy interrupts
-    // smnhack(w, 0x13F0_0004, 0x0010_0400u32);
-    // smnhack(w, 0x13F0_0064, 0x0010_0400u32); // 847405
-
     // It is hard to say if we need to do this.
     if true {
         let v = unsafe { Msr::new(0xc001_1004).read() };
@@ -157,6 +153,10 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     if true {
         msrs(w);
     }
+
+    // disable legacy interrupts
+    smnhack(w, 0x13F0_0004, 0x0010_0400u32);
+    smnhack(w, 0x13F0_0064, 0x0010_0400u32); // 847405
 
     // see src/soc/amd/common/df/src/lib.rs
     let io_port_decode_enable = config32(PciAddress {

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -5,8 +5,8 @@
 #![feature(global_asm)]
 #![feature(abi_x86_interrupt)]
 
-use arch::bzimage::BzImage;
 use arch::ioport::IOPort;
+use boot::boot;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use cpu::model::amd_family_id;
@@ -25,8 +25,6 @@ mod msr;
 use msr::msrs;
 // mod c00;
 // use c00::c00;
-mod acpi;
-use acpi::setup_acpi_tables;
 mod interrupts;
 use interrupts::init_idt;
 use x86_64::registers::model_specific::Msr;
@@ -37,9 +35,6 @@ use wrappers::DoD;
 use x86_64::instructions::interrupts::int3;
 
 use core::ptr;
-// Until we are done hacking on this, use our private copy.
-// Plan to copy it back later.
-global_asm!(include_str!("bootblock.S"));
 
 fn poke32(a: u32, v: u32) -> () {
     let y = a as *mut u32;
@@ -54,160 +49,11 @@ fn poke8(a: u32, v: u8) -> () {
     }
 }
 
-fn peek8(a: u32) -> u8 {
-    let y = a as *mut u8;
-    unsafe { ptr::read_volatile(y) }
-}
-
-/// Write 32 bits to port
-unsafe fn outl(port: u16, val: u32) {
-    llvm_asm!("outl %eax, %dx" :: "{dx}"(port), "{al}"(val));
-}
-
-/// Read 32 bits from port
-unsafe fn inl(port: u16) -> u32 {
-    let ret: u32;
-    llvm_asm!("inl %dx, %eax" : "={ax}"(ret) : "{dx}"(port) :: "volatile");
-    return ret;
-}
 fn peek32(a: u32) -> u32 {
     let y = a as *const u32;
     unsafe { ptr::read_volatile(y) }
 }
-// extern "C" {
-//     fn run32(w: &mut impl core::fmt::Write, start_address: usize, dtb: usize);
-// }
 
-fn peek(a: u64) -> u64 {
-    let y = a as *const u64;
-    unsafe { ptr::read_volatile(y) }
-}
-
-fn peekb(a: u64) -> u8 {
-    let y = a as *const u8;
-    unsafe { ptr::read_volatile(y) }
-}
-
-// Returns a slice of u32 for each sequence of hex chars in a.
-fn hex(a: &[u8], vals: &mut Vec<u64, U8>) -> () {
-    let mut started: bool = false;
-    let mut val: u64 = 0u64;
-    for c in a.iter() {
-        let v = *c;
-        if v >= b'0' && v <= b'9' {
-            started = true;
-            val = val << 4;
-            val = val + (*c - b'0') as u64;
-        } else if v >= b'a' && v <= b'f' {
-            started = true;
-            val = (val << 4) | (*c - b'a' + 10) as u64;
-        } else if v >= b'A' && v <= b'F' {
-            started = true;
-            val = (val << 4) | (*c - b'A' + 10) as u64;
-        } else if started {
-            vals.push(val).unwrap();
-            val = 0;
-        }
-    }
-}
-
-fn mem(w: &mut impl core::fmt::Write, a: Vec<u8, U16>) -> () {
-    let mut vals: Vec<u64, U8> = Vec::new();
-    hex(&a, &mut vals);
-
-    // I wish I knew rust. This code is shit.
-    for a in vals.iter() {
-        let m = peek(*a);
-        write!(w, "{:x?}: {:x?}\r\n", *a, m).unwrap();
-    }
-}
-
-fn ind(w: &mut impl core::fmt::Write, a: Vec<u8, U16>) -> () {
-    let mut vals: Vec<u64, U8> = Vec::new();
-    hex(&a, &mut vals);
-
-    // I wish I knew rust. This code is shit.
-    for a in vals.iter() {
-        let m = unsafe { inl(*a as u16) };
-        write!(w, "{:x?}: {:x?}\r\n", *a, m).unwrap();
-    }
-}
-
-fn out(w: &mut impl core::fmt::Write, a: Vec<u8, U16>) -> () {
-    let mut vals: Vec<u64, U8> = Vec::new();
-    hex(&a, &mut vals);
-
-    // I wish I knew rust. This code is shit.
-    for i in 0..vals.len() / 2 {
-        let a = vals[i * 2] as u16;
-        let v = vals[i * 2 + 1] as u32;
-        unsafe {
-            outl(a, v);
-        };
-        write!(w, "{:x?}: {:x?}\r\n", a, v).unwrap();
-    }
-}
-
-fn memb(w: &mut impl core::fmt::Write, a: Vec<u8, U16>) -> () {
-    let mut vals: Vec<u64, U8> = Vec::new();
-    hex(&a, &mut vals);
-    write!(w, "dump bytes: {:x?}\r\n", vals).expect("Failed to write.");
-    for a in vals.iter() {
-        for i in 0..16 {
-            let m = peekb(*a + i);
-            write!(w, "{:x?}: {:x?}\r\n", *a + i, m).unwrap();
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn _asdebug(w: &mut impl core::fmt::Write, a: u64) -> () {
-    write!(w, "here we are in asdebug\r\n").unwrap();
-    write!(w, "stack is {:x?}\r\n", a).unwrap();
-    consdebug(w);
-    write!(w, "back to hell\r\n").unwrap();
-}
-
-fn consdebug(w: &mut impl core::fmt::Write) -> () {
-    let mut done: bool = false;
-    let newline: [u8; 2] = [10, 13];
-    while done == false {
-        let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
-        let mut line: Vec<u8, U16> = Vec::new();
-        loop {
-            let mut c: [u8; 1] = [12; 1];
-            uart0.pread(&mut c, 1).unwrap();
-            uart0.pwrite(&c, 1).unwrap();
-            line.push(c[0]).unwrap();
-            if c[0] == 13 || c[0] == 10 || c[0] == 4 {
-                uart0.pwrite(&newline, 2).unwrap();
-                break;
-            }
-            if line.len() > 15 {
-                break;
-            }
-        }
-        match line[0] {
-            0 | 4 => {
-                done = true;
-            }
-            b'm' => {
-                mem(w, line);
-            }
-            b'i' => {
-                ind(w, line);
-            }
-            b'o' => {
-                out(w, line);
-            }
-            b'h' => {
-                memb(w, line);
-            }
-            _ => {}
-        }
-    }
-}
-//global_asm!(include_str!("init.S"));
 fn smnhack(w: &mut impl core::fmt::Write, reg: u32, want: u32) -> () {
     let got = smn_read(reg);
     write!(w, "{:x}: got {:x}, want {:x}\r\n", reg, got, want).unwrap();
@@ -314,16 +160,6 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
         write!(w, "0x1b is {:x} \r\n", Msr::new(0x1b).read()).unwrap();
     }
 
-    let payload = &mut BzImage {
-        low_mem_size: 0x8000_0000,
-        high_mem_start: 0x1_0000_0000,
-        high_mem_size: 0,
-        // TODO: get this from the FDT.
-        rom_base: 0xffc0_0000,
-        rom_size: 0x30_0000,
-        load: 0x0100_0000,
-        entry: 0x100_0200,
-    };
     if true {
         msrs(w);
     }
@@ -335,12 +171,6 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
         }
     }
 
-    write!(w, "Write acpi tables\r\n").unwrap();
-    if (true) {
-        setup_acpi_tables(w, 0xf0000, 1);
-    }
-    write!(w, "Wrote bios tables, entering debug\r\n").unwrap();
-
     if false {
         msrs(w);
     }
@@ -350,11 +180,8 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     poke32(0xfee000d0, 0x1000000);
     write!(w, "LDN is {:x}\r\n", peek32(0xfee000d0)).unwrap();
     write!(w, "loading payload with fdt_address {}\r\n", fdt_address).unwrap();
-    payload.load(w).unwrap();
-    write!(w, "Back from loading payload, call debug\r\n").unwrap();
 
-    write!(w, "Running payload entry is {:x}\r\n", payload.entry).unwrap();
-    payload.run(w);
+    boot(w, fdt_address);
 
     write!(w, "Unexpected return from payload\r\n").unwrap();
     arch::halt()

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -36,24 +36,6 @@ use x86_64::instructions::interrupts::int3;
 
 use core::ptr;
 
-fn poke32(a: u32, v: u32) -> () {
-    let y = a as *mut u32;
-    unsafe {
-        ptr::write_volatile(y, v);
-    }
-}
-fn poke8(a: u32, v: u8) -> () {
-    let y = a as *mut u8;
-    unsafe {
-        ptr::write_volatile(y, v);
-    }
-}
-
-fn peek32(a: u32) -> u32 {
-    let y = a as *const u32;
-    unsafe { ptr::read_volatile(y) }
-}
-
 fn smnhack(w: &mut impl core::fmt::Write, reg: u32, want: u32) -> () {
     let got = smn_read(reg);
     write!(w, "{:x}: got {:x}, want {:x}\r\n", reg, got, want).unwrap();
@@ -176,14 +158,9 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     }
     // TODO: Is this specific to Rome?
     // c00(w);
-    write!(w, "LDN is {:x}\r\n", peek32(0xfee000d0)).unwrap();
-    poke32(0xfee000d0, 0x1000000);
-    write!(w, "LDN is {:x}\r\n", peek32(0xfee000d0)).unwrap();
-    write!(w, "loading payload with fdt_address {}\r\n", fdt_address).unwrap();
 
     boot(w, fdt_address);
 
-    write!(w, "Unexpected return from payload\r\n").unwrap();
     arch::halt()
 }
 

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![no_main]
 #![feature(global_asm)]
+#![feature(abi_x86_interrupt)]
 
 use arch::bzimage::BzImage;
 use arch::ioport::IOPort;
@@ -25,11 +26,14 @@ use msr::msrs;
 // use c00::c00;
 mod acpi;
 use acpi::setup_acpi_tables;
+mod interrupts;
+use interrupts::init_idt;
 use x86_64::registers::model_specific::Msr;
 extern crate heapless; // v0.4.x
 use heapless::consts::*;
 use heapless::Vec;
 use wrappers::DoD;
+use x86_64::instructions::interrupts::int3;
 
 use core::ptr;
 // Until we are done hacking on this, use our private copy.
@@ -261,6 +265,19 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
         console.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
     }
     let w = &mut print::WriteToDyn::new(console);
+
+    init_idt();
+
+    if false {
+        write!(w, "Let's go BOOM!\r\n").unwrap();
+        //panic!("AAAAAAAAAH"); <-- this works :)
+        unsafe {
+            // llvm_asm!("int3" :::: "volatile");
+            int3();
+            // llvm_asm!("xorl %ebx, %ebx\ndiv %ebx" : /* no outputs */ : /* no inputs */ : "ebx" : "volatile");
+        }
+        write!(w, "Didn't explode :(\r\n").unwrap();
+    }
 
     // It is hard to say if we need to do this.
     if true {

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -273,9 +273,7 @@ pub extern "C" fn _start(fdt_address: usize) -> ! {
     let mut text_output_drivers = m.text_output_drivers();
     let console = &mut DoD::new(&mut text_output_drivers);
 
-    for _i in 1..32 {
-        console.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
-    }
+    console.pwrite(b"Welcome to oreboot\r\n", 0).unwrap();
     let w = &mut print::WriteToDyn::new(console);
 
     init_idt();

--- a/src/mainboard/asrock/a300m-stx/src/main.rs
+++ b/src/mainboard/asrock/a300m-stx/src/main.rs
@@ -227,7 +227,8 @@ fn cpu_init(w: &mut impl core::fmt::Write) -> Result<(), &str> {
         Some(family_id) => {
             match amd_model_id {
                 Some(model_id) => {
-                    write!(w, "AMD CPU: family {:X}h, model {:X}h\r\n", family_id, model_id).unwrap();
+                    write!(w, "AMD CPU: family {:X}h, model {:X}h\r\n", family_id, model_id)
+                        .unwrap();
                 }
                 None => (),
             }

--- a/src/mainboard/asrock/a300m-stx/src/mainboard.rs
+++ b/src/mainboard/asrock/a300m-stx/src/mainboard.rs
@@ -145,6 +145,7 @@ impl Driver for MainBoard {
 
             // Set up the legacy decode for UART 0.
             //(*FCH_UART_LEGACY_DECODE).set(FCH_LEGACY_3F8_SH);
+            (*FCH_UART_LEGACY_DECODE).set(0);
 
             // IOAPIC
             //     wmem fed80300 e3070b77

--- a/src/mainboard/asrock/a300m-stx/src/mainboard.rs
+++ b/src/mainboard/asrock/a300m-stx/src/mainboard.rs
@@ -83,20 +83,20 @@ where
 
 // WIP: mainboard driver. I mean the concept is a WIP.
 pub struct MainBoard {
-    com1: I8250<IOPort>,
-    // debug: DebugPort<IOPort>,
+    // com1: I8250<IOPort>,
+    debug: DebugPort<IOPort>,
 }
 
 impl MainBoard {
     pub fn new() -> MainBoard {
         // Uncomment for port 0x80 testing, but it's sluggish and mutually
         // exclusive on the super I/O
-        // Self { debug: DebugPort::new(0x80, IOPort {}) }
-        Self { com1: I8250::new(0x3f8, 0, IOPort {}) }
+        Self { debug: DebugPort::new(0x80, IOPort {}) }
+        // Self { com1: I8250::new(0x3f8, 0, IOPort {}) }
     }
     pub fn text_output_drivers(&mut self) -> [&mut dyn Driver; 1] {
-        // [&mut self.debug]
-        [&mut self.com1]
+        [&mut self.debug]
+        // [&mut self.com1]
     }
 }
 

--- a/src/mainboard/asrock/a300m-stx/src/mainboard.rs
+++ b/src/mainboard/asrock/a300m-stx/src/mainboard.rs
@@ -43,6 +43,9 @@ const ACPI_MMIO_BASE: usize = 0xfed8_0000;
 //const IOMUX_BASE: *mut u8 = (ACPI_MMIO_BASE + 0xd00) as *mut _;
 const IOMUX_BASE: *const [VolatileCell<u8>; 256] = (ACPI_MMIO_BASE + 0xd00) as *const _; // Note: 256 u8 block--one u8 per pinctrl
 const AOAC_BASE: usize = ACPI_MMIO_BASE + 0x1e00;
+const PM_DECODE_EN: usize = ACPI_MMIO_BASE + 0x0300;
+const WATCHDOG_TIMER_EN: u8 = 1 << 7;
+const SMBUS_ASF_IO_EN: u8 = 1 << 4;
 
 // See coreboot:src/soc/amd/common/block/include/amdblocks/aoac.h
 
@@ -119,7 +122,11 @@ impl Driver for MainBoard {
     fn init(&mut self) -> Result<()> {
         unsafe {
             // FCH PM DECODE EN
-            poke(0xfed80300 as *mut u32, 0xe3070b77);
+            // 1110 0011  0000 0111  0000 1011  0111 0111
+            // poke(PM_DECODE_EN as *mut u32, 0xe3070b77);
+            // 1110 0011  0000 0111  0000 1011  1111 0111
+            poke(PM_DECODE_EN as *mut u32, 0xe3070bf7);
+            // pokers(&(*PM_DECODE_EN)[usize::from(n * 2)], 0, WATCHDOG_TIMER_EN | SMBUS_ASF_IO_EN);
 
             // Knowledge from coreboot to get minimal serials working.
             // clock defaults are NOT fine.

--- a/src/mainboard/asrock/a300m-stx/src/mainboard.rs
+++ b/src/mainboard/asrock/a300m-stx/src/mainboard.rs
@@ -83,20 +83,20 @@ where
 
 // WIP: mainboard driver. I mean the concept is a WIP.
 pub struct MainBoard {
-    // com1: I8250<IOPort>,
-    debug: DebugPort<IOPort>,
+    com1: I8250<IOPort>,
+    // debug: DebugPort<IOPort>,
 }
 
 impl MainBoard {
     pub fn new() -> MainBoard {
         // Uncomment for port 0x80 testing, but it's sluggish and mutually
         // exclusive on the super I/O
-        Self { debug: DebugPort::new(0x80, IOPort {}) }
-        // Self { com1: I8250::new(0x3f8, 0, IOPort {}) }
+        // Self { debug: DebugPort::new(0x80, IOPort {}) }
+        Self { com1: I8250::new(0x3f8, 0, IOPort {}) }
     }
     pub fn text_output_drivers(&mut self) -> [&mut dyn Driver; 1] {
-        [&mut self.debug]
-        // [&mut self.com1]
+        // [&mut self.debug]
+        [&mut self.com1]
     }
 }
 

--- a/src/mainboard/asrock/a300m-stx/src/mainboard.rs
+++ b/src/mainboard/asrock/a300m-stx/src/mainboard.rs
@@ -35,6 +35,9 @@ const SMB_UART_CONFIG_UART1_1_8M: u32 = 1 << (SMB_UART_1_8M_SHIFT + 1);
 
 const FCH_UART_LEGACY_DECODE: *const VolatileCell<u16> = 0xfedc_0020 as *const _;
 const FCH_LEGACY_3F8_SH: u16 = 1 << 3;
+// ACPI calls this WUR3, which means ... ?
+// This is two-bit field for bits 15:14.
+const FCH_WUR3: u16 = 1 << 14;
 //const FCH_LEGACY_2F8_SH: u16 = 1 << 1;
 
 // See coreboot:src/soc/amd/common/block/include/amdblocks/acpimmio_map.h
@@ -151,14 +154,17 @@ impl Driver for MainBoard {
             pinctrl(139, 0); // [UART0_INTR, AGPIO139][0]; Note: The reset default is 0
 
             // Set up the legacy decode for UART 0.
-            //(*FCH_UART_LEGACY_DECODE).set(FCH_LEGACY_3F8_SH);
+            // (*FCH_UART_LEGACY_DECODE).set(FCH_LEGACY_3F8_SH | FCH_WUR3);
+            // Turn off legacy decode for UART 0.
             (*FCH_UART_LEGACY_DECODE).set(0);
 
             // IOAPIC
             //     wmem fed80300 e3070b77
             //    wmem fed00010 3
-            poke(0xfed00010 as *mut u32, 3); //HPETCONFIG
-            pokers32(0xfed00010 as *mut u32, 0, 8);
+            pokers32(0xfed00010 as *mut u32, 0, 3); //HPETCONFIG
+
+            // pokers32(0xfed00010 as *mut u32, 0, 8);
+
             // THis is likely not needed but.
             //poke32(0xfed00108, 0x5b03d997);
 

--- a/src/mainboard/asrock/a300m-stx/src/msr.rs
+++ b/src/mainboard/asrock/a300m-stx/src/msr.rs
@@ -209,6 +209,8 @@ pub fn msrs(w: &mut impl core::fmt::Write) {
 
     read_write_msr(w, 0xc001_0073, 0x813); // CStateBaseAddr - C-state Base Address
     read_write_msr(w, 0xc001_0074, 0x289); // CpuWdtCfg - CPU Watchdog Timer
+
+    // read_write_msr(w, 0xC001_0074, 0x7 << 3 | 0x1); // enable watchdog
     read_write_msr(w, 0xc001_0111, 0xafba2000); // SMM_BASE - SMM Base Address
     read_write_msr(w, 0xc001_0112, 0xac000000); // SMMAddr - SMM TSeg Base Address
     read_write_msr(w, 0xc001_0113, 0xfffffc006003); // SMMMask - SMM TSeg Mask

--- a/src/mainboard/asrock/a300m-stx/start.S
+++ b/src/mainboard/asrock/a300m-stx/start.S
@@ -100,10 +100,10 @@ movb $0x21, %al ##
 outb %al, $0x2f
 
 # 2f -> 40; uncomment to switch to port 0x80 forward instead of 3f8 on UART
-##movb $0x2f, %al ##
-##outb %al, $0x2e
-##movb $0x40, %al ##
-##outb %al, $0x2f
+movb $0x2f, %al ##
+outb %al, $0x2e
+movb $0x40, %al ##
+outb %al, $0x2f
 
 ######## LDN 0x07 ########
 ## not yet working, probably relies on some global registers

--- a/src/mainboard/asrock/a300m-stx/start.S
+++ b/src/mainboard/asrock/a300m-stx/start.S
@@ -308,9 +308,11 @@ gdtptr16:
 	nop
 	/* WE ARE GETTING HERE! */
 	outb %al, $0x80
-	// Uses first part of gdt as stack.
+  // TODO:
+	// Using the first part of the gdt as stack might be insufficient.
 	// This jumps to the bootblock (bootblob.bin)
-	movl $0x76fe0010, %esp
+	movl $0x10000, %esp #
+	# movl $0x76fe0010, %esp
 	push $0x76fe0000 # 0x76c00000 (dest) + 0x3e0000 (offset in fixed-dtfs.dts)
 	# We patch the PSP dir entry to have it copy our image to 0x76c00000 in RAM
 	ret

--- a/src/mainboard/asrock/a300m-stx/start.S
+++ b/src/mainboard/asrock/a300m-stx/start.S
@@ -100,10 +100,10 @@ movb $0x21, %al ##
 outb %al, $0x2f
 
 # 2f -> 40; uncomment to switch to port 0x80 forward instead of 3f8 on UART
-movb $0x2f, %al ##
-outb %al, $0x2e
-movb $0x40, %al ##
-outb %al, $0x2f
+##movb $0x2f, %al ##
+##outb %al, $0x2e
+##movb $0x40, %al ##
+##outb %al, $0x2f
 
 ######## LDN 0x07 ########
 ## not yet working, probably relies on some global registers

--- a/src/mainboard/asrock/a300m-stx/start.S
+++ b/src/mainboard/asrock/a300m-stx/start.S
@@ -311,7 +311,7 @@ gdtptr16:
   // TODO:
 	// Using the first part of the gdt as stack might be insufficient.
 	// This jumps to the bootblock (bootblob.bin)
-	movl $0x10000, %esp #
+	movl $0x90000, %esp #
 	# movl $0x76fe0010, %esp
 	push $0x76fe0000 # 0x76c00000 (dest) + 0x3e0000 (offset in fixed-dtfs.dts)
 	# We patch the PSP dir entry to have it copy our image to 0x76c00000 in RAM

--- a/src/mainboard/asrock/a300m-stx/watchdog.md
+++ b/src/mainboard/asrock/a300m-stx/watchdog.md
@@ -1,0 +1,126 @@
+## Registers
+
+p 486
+
+9.2.10.2 Power Management (PM) Registers
+
+Table 81: ACPI MMIO Space Allocation
+
+```
+0x0BFF-0x0B00
+```
+
+The PM register space is accessed through two methods:
+ • Indirect IO access through IOCD6 [PM_Index] and IOCD7 [PM_Data]. Software
+   first programs the offset into the index register IOCD6 and then reads from
+   or writes to the data register IOCD7.
+ • Direct memory mapped access through the AcpiMmio region. The PM registers
+   range from FED8_0000h+300h to FED8_0000h+3FFh. See PMx04[MmioEn] for details
+   on the AcpiMmio region.
+
+PMx000 [DecodeEn] (FCH::PM::PmDecodeEn)
+Read-write. Reset: 2302_0B10h.
+`_aliasHOST; PMx000; PM=FED8_0300h`
+
+27:26 WatchDogOptions. Read-write. Reset: 0h. Enable for normal WatchDog Timer operation.
+  ValidValues:
+  Value Description
+  0h Enable WatchDog Timer.
+  3h-1h Reserved.
+
+7 WatchdogTmrEn. Read-write. Reset: 0. 1=Enable IOAPIC memory (FEB0_0000h ~ FEB0_0003h) decoding, and enable WatchDog Timer operation.
+
+
+PMx048 [PGPwrEnDly] (FCH::PM::WatchdogTimerEn)
+Read-write. Reset: 5935_2B21h.
+`_aliasHOST; PMx048; PM=FED8_0300h`
+
+ Bits Description
+ 31:24 PG1PwrDownDlyTmr. Read-write. Reset: 59h. PG1 Power Down delay timer.
+ 23:16 XhcPwrEnDlyTmr. Read-write. Reset: 35h. XHC Power Enable delay timer.
+ 15:8 PG2PwrEnDlyTmr. Read-write. Reset: 2Bh. PG2 Power Enable delay timer.
+ 8:0 PG1aPwrEnDlyTmr. Read-write. Reset: 21h. PG1a Power En delay timer.
+
+PMx0C0 [S5/Reset Status] (FCH::PM::S5ResetStat)
+ Reset: 0000_0800h.
+
+This register shows the source of previous reset.
+`_aliasHOST; PMx0C0; PM=FED8_0300h`
+
+25 WatchdogIssueReset. Read,Write-1-to-clear. Reset: 0. Bits[27:16] will be
+   cleared by the last reset event except the associated bit will be set.
+
+
+MSRC001_0074 [CPU Watchdog Timer] (Core::X86::Msr::CpuWdtCfg)
+
+ Read-write. Reset: 0000_0000_0000_0000h.
+`_lthree0_core[3:0]; MSRC001_0074`
+
+ Bits Description
+ 63:7 Reserved.
+ 6:3 CpuWdtCountSel: CPU watchdog timer count select. Read-write. Reset: 0h.
+     CpuWdtCountSel and CpuWdtTimeBase together specify the time period required
+     for the WDT to expire. The time period is ((the multiplier specified by
+     CpuWdtCountSel) * (the time base specified by CpuWdtTimeBase)). The actual
+     timeout period may be anywhere from zero to one increment less than the
+     values specified, due to non-deterministic behavior.
+
+     ValidValues:
+     Value Description
+     0h 4095
+     1h 2047
+     2h 1023
+     3h 511
+     4h 255
+     5h 127
+     6h 63
+     7h 31
+     8h 8191
+     9h 16383
+     Fh-Ah Reserved
+ 2:1 CpuWdtTimeBase: CPU watchdog timer time base. Read-write. Reset: 0h.
+     Specifies the time base for the timeout period specified in CpuWdtCountSel.
+     ValidValues:
+     Value Description
+     0h 1.31ms
+     1h 1.28us
+     3h-2h Reserved
+ 0 CpuWdtEn: CPU watchdog timer enable. Read-write.
+   Reset: 0. Init: BIOS,1. 1=The WDT is enabled.
+
+
+p 354
+
+9.1.13 Reset Overview
+
+ Below are definitions of the various reset types:
+ • Type 0 reset (S5 Reset): RsmRst and UserRst.
+ • Type 1 reset (reset initiated by software or system): CF9, KBRst, Sync_flood,
+   ASF_remote_reset, Fail_boot, Watchdog Timer reset, toggling of PwrGood
+   (SLP_S3#/SLP_S5# remain de-asserted at high), SHUTDOWN command, INIT/PORT92.
+ • Type 2 reset (Sleep Reset): S3/S4/S5 reset.
+ • Type 3 reset (Fatal_error_reset or reset caused by hardware exception):
+   4s-shutdown, thermal trip, ASF_remotePowerDown.
+ • Type 4 reset (any reset from above): Type 0 or Type 1 or Type 2 or Type 3.
+
+
+p 498
+
+PMx0C0 [S5/Reset Status] (FCH::PM::S5ResetStat)
+
+ Reset: 0000_0800h.
+
+This register shows the source of previous reset.
+` _aliasHOST; PMx0C0; PM=FED8_0300h`
+
+ Bits Description
+ 31:28 Reserved.
+ 27 SyncFlood. Read,Write-1-to-clear. Reset: 0. System reset was caused by a
+    SYNC_FLOOD event which was due to an UE error or caused by a SHUTDOWN
+    command from CPU if FCH::PM::PciCtl[ShutDownOption]. Bits[27:16] will be
+    cleared by the last reset event, except the associated bit will be set.
+ 26 RemoteResetFromASF. Read,Write-1-to-clear. Reset: 0. System reset was caused
+    by a remote RESET command from ASF. Bits[27:16] will be cleared by the last
+    reset event, except the associated bit will be set.
+ 25 WatchdogIssueReset. Read,Write-1-to-clear. Reset: 0. Bits[27:16] will be
+    cleared by the last reset event except the associated bit will be set.

--- a/src/soc/amd/common/boot/src/acpi.rs
+++ b/src/soc/amd/common/boot/src/acpi.rs
@@ -48,8 +48,9 @@ pub fn setup_acpi_tables(w: &mut impl core::fmt::Write, start: usize) -> usize {
     write(w, gencsum(rsdp_offset, rsdp_offset + ACPI_RSDP_XCHECKSUM_LENGTH), rsdp_offset, ACPI_RSDP_XCHECKSUM_OFFSET); // XXX
     debug_assert_eq!(acpi_tb_checksum(rsdp_offset, rsdp_offset + ACPI_RSDP_XCHECKSUM_LENGTH), 0);
 
-    panic!("HEEEEEEEELP");
+    // panic!("HEEEEEEEELP");
 
+    /*
     // xsdt - Extended System Description Table
     let xsdt_total_length = size_of::<AcpiTableHeader>() + size_of::<u64>() * NUM_XSDT_ENTRIES;
     let xsdt = AcpiTableHeader { signature: SIG_XSDT, length: xsdt_total_length as u32, revision: 1, ..AcpiTableHeader::new() };
@@ -58,7 +59,6 @@ pub fn setup_acpi_tables(w: &mut impl core::fmt::Write, start: usize) -> usize {
     let xsdt_entries: [u64; NUM_XSDT_ENTRIES] = [fadt_offset as u64, madt_offset as u64, mcfg_offset as u64, hpet_offset as u64];
 
     write(w, xsdt_entries, xsdt_entry_offset, 0);
-    /*
     write(w, gencsum(xsdt_offset, xsdt_offset + xsdt_total_length), xsdt_offset, ACPI_TABLE_HEADER_CHECKSUM_OFFSET); // XXX
     debug_assert_eq!(acpi_tb_checksum(xsdt_offset, xsdt_offset + xsdt_total_length), 0);
 

--- a/src/soc/amd/common/boot/src/acpi.rs
+++ b/src/soc/amd/common/boot/src/acpi.rs
@@ -48,6 +48,7 @@ pub fn setup_acpi_tables(w: &mut impl core::fmt::Write, start: usize) -> usize {
     write(w, gencsum(rsdp_offset, rsdp_offset + ACPI_RSDP_XCHECKSUM_LENGTH), rsdp_offset, ACPI_RSDP_XCHECKSUM_OFFSET); // XXX
     debug_assert_eq!(acpi_tb_checksum(rsdp_offset, rsdp_offset + ACPI_RSDP_XCHECKSUM_LENGTH), 0);
 
+    /*
     // xsdt - Extended System Description Table
     let xsdt_total_length = size_of::<AcpiTableHeader>() + size_of::<u64>() * NUM_XSDT_ENTRIES;
     let xsdt = AcpiTableHeader { signature: SIG_XSDT, length: xsdt_total_length as u32, revision: 1, ..AcpiTableHeader::new() };
@@ -176,6 +177,6 @@ pub fn setup_acpi_tables(w: &mut impl core::fmt::Write, start: usize) -> usize {
     };
     write(w, hpet, hpet_offset, 0);
     write(w, gencsum(hpet_offset, hpet_offset + size_of::<AcpiTableHpet>()), hpet_offset, ACPI_TABLE_HEADER_CHECKSUM_OFFSET);
-
+    */
     round_up_4k(total_size)
 }

--- a/src/soc/amd/common/boot/src/acpi.rs
+++ b/src/soc/amd/common/boot/src/acpi.rs
@@ -48,7 +48,8 @@ pub fn setup_acpi_tables(w: &mut impl core::fmt::Write, start: usize) -> usize {
     write(w, gencsum(rsdp_offset, rsdp_offset + ACPI_RSDP_XCHECKSUM_LENGTH), rsdp_offset, ACPI_RSDP_XCHECKSUM_OFFSET); // XXX
     debug_assert_eq!(acpi_tb_checksum(rsdp_offset, rsdp_offset + ACPI_RSDP_XCHECKSUM_LENGTH), 0);
 
-    /*
+    panic!("HEEEEEEEELP");
+
     // xsdt - Extended System Description Table
     let xsdt_total_length = size_of::<AcpiTableHeader>() + size_of::<u64>() * NUM_XSDT_ENTRIES;
     let xsdt = AcpiTableHeader { signature: SIG_XSDT, length: xsdt_total_length as u32, revision: 1, ..AcpiTableHeader::new() };
@@ -57,6 +58,7 @@ pub fn setup_acpi_tables(w: &mut impl core::fmt::Write, start: usize) -> usize {
     let xsdt_entries: [u64; NUM_XSDT_ENTRIES] = [fadt_offset as u64, madt_offset as u64, mcfg_offset as u64, hpet_offset as u64];
 
     write(w, xsdt_entries, xsdt_entry_offset, 0);
+    /*
     write(w, gencsum(xsdt_offset, xsdt_offset + xsdt_total_length), xsdt_offset, ACPI_TABLE_HEADER_CHECKSUM_OFFSET); // XXX
     debug_assert_eq!(acpi_tb_checksum(xsdt_offset, xsdt_offset + xsdt_total_length), 0);
 

--- a/src/soc/amd/common/smn/src/lib.rs
+++ b/src/soc/amd/common/smn/src/lib.rs
@@ -25,9 +25,9 @@ pub fn smn_read(a: u32) -> u32 {
 
 pub fn smn_write(a: u32, v: u32) {
     unsafe {
-        outl(0xcf8, 0x800000b8);
+        outl(0xcf8, 0x8000_00b8);
         outl(0xcfc, a);
-        outl(0xcf8, 0x800000bc);
+        outl(0xcf8, 0x8000_00bc);
         outl(0xcfc, v);
     }
 }

--- a/src/soc/amd/picasso/src/lib.rs
+++ b/src/soc/amd/picasso/src/lib.rs
@@ -21,5 +21,12 @@ pub fn soc_init(w: &mut impl core::fmt::Write) -> Result<(), &'static str> {
             write!(w, "MP1 smu version error: {:x?}\r\n", e).unwrap();
         }
     }
+
+    let topology = df::FabricTopology::new();
+    // {:#x?} doesn't work correctly because it only prints LF
+    // for newline, no CR.
+    // write!(w, "Topology: {:x?}\r\n", topology).unwrap();
+    //write!(w, "PIEs: {:?}\r\n", topology.pie_count);
+    //write!(w, "IOMS: {:?}\r\n", topology.ioms_count);
     Ok(())
 }

--- a/src/soc/amd/picasso/src/lib.rs
+++ b/src/soc/amd/picasso/src/lib.rs
@@ -22,11 +22,12 @@ pub fn soc_init(w: &mut impl core::fmt::Write) -> Result<(), &'static str> {
         }
     }
 
-    let topology = df::FabricTopology::new();
+    //let topology = df::FabricTopology::new();
     // {:#x?} doesn't work correctly because it only prints LF
     // for newline, no CR.
     // write!(w, "Topology: {:x?}\r\n", topology).unwrap();
     //write!(w, "PIEs: {:?}\r\n", topology.pie_count);
-    //write!(w, "IOMS: {:?}\r\n", topology.ioms_count);
+    // write!(w, "IOMS: {:?}\r\n", topology.ioms_count);
+    // write!(w, "2nd: {:?}\r\n", topology.components[0].instance_id);
     Ok(())
 }


### PR DESCRIPTION
- asrock/a300m-stx: Remove extraneous MSR APIC configuration
- soc/amd/smn: format numbers with underscores
- asrock/a300m-stx: Exceptions WIP
- go boom
- timer
- debug print crap
- Revert "debug print crap"
- wip
- soc/picasso: df topology
- soc/picasso: topology
- asrock/a300m-stx: disable legacy UART decode
- asrock/a300m-stx: switch to port 0x80 debug output
- Revert "asrock/a300m-stx: switch to port 0x80 debug output"
- asrock/a300m-stx: make code readable
- asrock/a300m-stx: make main readable
- asrock/a300m-stx: SMN hack setup
- asrock/a300m-stx: SMN WIP
- asrock/a300m-stx: comment out SMN hack again
- asrock/a300m-stx: put the stack somewhere else than GDT
- asrock/a300m-stx: use EAX instead of ESP for writing PML4 to CR3
- asrock/a300m-stx: move stack again
- asrock/a300m-stx: print welcome once, not 32 times
- asrock/a300m-stx: ACPI table debug
- asrock/a300m-stx: ACPI table debug
- asrock/a300m-stx: comment out some ACPI
- asrock/a300m-stx: [WIP] watchdog notes
- asrock/a300m-stx: [WIP] watchdog fun
- asrock/a300m-stx: switch to using amd/common/boot
- asrock/a300m-stx: remove redundant and unused code
- AMD: Update x86_64 dependency to 0.14.0.
- asrock/a300m-stx: downgrade x86_64 to 0.13.x
- TEMP HACK: strip down common APCI setup
- asrock/a300m-stx: comment out acpi_setup
