### PR TITLE
soc/amd/common: Turn off CD and NW in CR0

### DIFF
--- a/src/soc/amd/common/boot/src/bootblock.S
+++ b/src/soc/amd/common/boot/src/bootblock.S
@@ -224,7 +224,10 @@ lme:
 	#define PG 0x80000000     //Paging        If 1, enable paging and use the § CR3 register, else disable paging.
 	#define CDNWTSMP 0x6000000a
 	//ANDL	/*$~(CD|NW|TS|MP)*/$~0x6000000a, %eax
+	// The most important thing here is enabling caching by clearing CD and NW
+	andl	$0x9ffffff5, %eax
 	//ORL	/*$(PG|WP)*/$0x80010000, %eax			/* Paging Enable */
+	// Consider re-enabling WP. But it's pretty pointless at this level with 1 GiB pages!
 	ORL	$0x80000000, %eax			/* Paging Enable */
 	movl	%eax, %cr0
 	ljmp $0x28, $_identity


### PR DESCRIPTION
Boot times with this time are unchanged, but for reference
0s RESET
12s first print
40s "on to payload..."
1:35 first kernel print
2:25 u-root prompt

The kernel in this case is
 Linux version 5.8.0 (rminnich@t510) (gcc (Ubuntu 10.2.0-13ubuntu1) 10.2.0, GNU ld (GNU Binutils for Ubuntu) 2.35.1) #16 Fri May 14 17:52:25 UTC 2021

commit bcf876870b95592b52519ed4aafcf9d95999bc9c (grafted, HEAD, tag: v5.8)

github.com/linuxboot/mainboards repo 74f1a1de20644143f48a1243addfda56e27b4395 with cpu.config

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>