### PR TITLE
mb/{emulation, sifive}: Fix typos

### DIFF
--- a/src/mainboard/emulation/qemu-riscv/fixed-dtfs.dts
+++ b/src/mainboard/emulation/qemu-riscv/fixed-dtfs.dts
@@ -10,7 +10,7 @@
         category = "Emulation";
         areas {
             area@0 {
-                description = "Boot Blob and Ramstage";
+                description = "Boot Blob and Romstage";
                 offset = <0x0>;
                 size = <0x80000>; // 512KiB
                 file = "$(TARGET_DIR)/bootblob.bin";

--- a/src/mainboard/sifive/hifive/fixed-dtfs.dts
+++ b/src/mainboard/sifive/hifive/fixed-dtfs.dts
@@ -11,7 +11,7 @@
         board-url = "https://www.sifive.com/boards/hifive-unleashed";
         areas {
             area@0 {
-                description = "Boot Blob and Ramstage";
+                description = "Boot Blob and Romstage";
                 size = <0x80000>; // 512KiB
                 file = "$(TARGET_DIR)/bootblob.bin";
             };


### PR DESCRIPTION
This patch fixes typos in boot phase name as Oreboot
doesn't have stage name Ramstage unlike coreboot.

Ramstage -> Romstage

Signed-off-by: Subrata Banik <subrata.banik@intel.com>