### PR TITLE
Remove language about lack of x86 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ https://dev.azure.com/azure0427/Oreboot%20Pipeline/_build/latest?definitionId=1&
 
 oreboot is a downstream fork of coreboot, i.e. oreboot is coreboot without 'c'.
 
-oreboot will only target truly open systems requiring no binary blobs. For now, that means no x86.
 oreboot is mostly written in Rust, with assembly where needed.
 
 oreboot currently only plans to support LinuxBoot payloads.


### PR DESCRIPTION
In an effort to support a larger breadth of platforms, oreboot is now
also targeting x86. In order to encourage x86 contributions, remove
language about oreboot explicitly not supporting x86 in the README.

Signed-off-by: Jordan Hand <jhand@google.com>