### PR TITLE
Add features to the rust preprocessor library

### DIFF
--- a/tools/rpp/Cargo.lock
+++ b/tools/rpp/Cargo.lock
@@ -10,6 +10,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,4 +60,27 @@ name = "rpp"
 version = "0.1.0"
 dependencies = [
  "regex",
+ "uuid",
 ]
+
+[[package]]
+name = "serde"
+version = "1.0.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"

--- a/tools/rpp/Cargo.toml
+++ b/tools/rpp/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2018"
 
 [dependencies]
 regex = "1.5.4"
+
+[dev-dependencies]
+uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/tools/rpp/src/testdata/sample.S
+++ b/tools/rpp/src/testdata/sample.S
@@ -10,7 +10,7 @@ comment
 #define C (1 << 10) // EOL comment
 
 test:
-    mov $MACRO, %rsp
+    mov $MACRO, %rsp /* test */
     mov $A, %rsp
     mov $B, %rsp
     mov $C, %rsp

--- a/tools/rpp/tests/test.rs
+++ b/tools/rpp/tests/test.rs
@@ -1,0 +1,38 @@
+use rpp;
+
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+
+use std::env::temp_dir;
+use uuid::Uuid;
+
+fn tmp_filename() -> String {
+    let mut dir = temp_dir();
+    dir.push(Uuid::new_v4().to_string());
+
+    dir.to_string_lossy().into_owned()
+}
+
+#[test]
+fn simple_include() {
+    let main = tmp_filename();
+    let inc = tmp_filename();
+
+    let test_string = format!("#include \"{}\"", inc);
+    let include_string = "keep";
+
+    let mut main_file = File::create(&main).unwrap();
+    let mut inc_file = File::create(&inc).unwrap();
+
+    main_file.write_all(test_string.as_bytes()).unwrap();
+    inc_file.write_all(include_string.as_bytes()).unwrap();
+
+    let mut rpp_ctx = rpp::Context::new();
+    let out: String = rpp::process_str(&test_string, &mut rpp_ctx).unwrap();
+
+    fs::remove_file(main).unwrap();
+    fs::remove_file(inc).unwrap();
+
+    assert!(out.contains("keep"));
+}

--- a/tools/rpp_procedural/src/lib.rs
+++ b/tools/rpp_procedural/src/lib.rs
@@ -1,15 +1,72 @@
 use proc_macro::TokenStream;
+use rpp::Context;
 use std::env;
+use std::fmt;
 use std::path::Path;
 
+#[derive(Debug, Clone)]
+struct BadInputError {
+    message: String,
+}
+
+impl fmt::Display for BadInputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl BadInputError {
+    pub fn new(message: String) -> Self {
+        BadInputError { message }
+    }
+}
+
+/// Parse an input TokenStream which contains a filename followed by any number
+/// of key-value pair macro definitions. Macro definitions will be added to
+/// the rpp_ctx.
+///
+/// Returns the filename.
+fn parse_input(input: TokenStream, rpp_ctx: &mut Context) -> Result<String, BadInputError> {
+    let input_str = input.to_string();
+    let mut args = input_str.split(',');
+
+    let in_file = args
+        .next()
+        .ok_or_else(|| BadInputError::new(String::from("No filename present")))?;
+    let unquoted_file = &in_file.trim()[1..in_file.len() - 1];
+
+    for define in args {
+        let trimmed = define.trim();
+        let unquoted_define = &trimmed[1..trimmed.len() - 1];
+        let mut parts = unquoted_define.splitn(2, '=');
+        let key = parts
+            .next()
+            .ok_or_else(|| BadInputError::new(String::from("Macro definition has no value")))?;
+
+        let value = match parts.next() {
+            Some(val) => val.trim(),
+            None => "",
+        };
+
+        rpp_ctx.add_macro(key, value);
+    }
+
+    Ok(unquoted_file.to_string())
+}
+
+/// Preprocess the an assembly file with 0 or more macro definitions.
+///
+/// Returns a string literal with preprocessed asm.
+///
+/// Sample usage:
+/// let asm_string = preprocess_asm!("file.asm", "A=1", "B=2");
 #[proc_macro]
 pub fn preprocess_asm(input: TokenStream) -> TokenStream {
-    let mut rpp_ctx = rpp::Context::new();
-    let in_file = input.to_string();
-    let p = &in_file[1..in_file.len() - 1];
+    let mut rpp_ctx = Context::new();
+    let in_file = parse_input(input, &mut rpp_ctx).unwrap();
 
     let curr_path = env::current_dir().unwrap();
-    let path = Path::new(&p);
+    let path = Path::new(&in_file);
 
     // Create a path to the asm directory
     let mut asm_dir = env::current_dir().unwrap();

--- a/tools/rpp_procedural/tests/test.rs
+++ b/tools/rpp_procedural/tests/test.rs
@@ -1,0 +1,22 @@
+use rpp_procedural::preprocess_asm;
+
+#[test]
+fn simple_preprocess() {
+    let out = preprocess_asm!("tests/testdata/simple.S");
+
+    assert!(out.contains("mov $1, %rax"));
+}
+
+#[test]
+fn inject_macros() {
+    let out = preprocess_asm!(
+        "tests/testdata/external_macros.S",
+        "EXTERNAL1=100",
+        "EXTERNAL2=200"
+    );
+
+    println!("{}", out);
+
+    assert!(out.contains("mov $100, %rax"));
+    assert!(out.contains("mov $200, %rax"));
+}

--- a/tools/rpp_procedural/tests/testdata/external_macros.S
+++ b/tools/rpp_procedural/tests/testdata/external_macros.S
@@ -1,0 +1,2 @@
+mov $EXTERNAL1, %rax
+mov $EXTERNAL2, %rax

--- a/tools/rpp_procedural/tests/testdata/simple.S
+++ b/tools/rpp_procedural/tests/testdata/simple.S
@@ -1,0 +1,3 @@
+#define TEST 1
+
+mov $TEST, %rax


### PR DESCRIPTION
To support more full-featured preprocessing, add the following features
to the rpp and rpp_procedural crates:
* Fix block comment bug that led to wrong line numbers in parsing errors
* Add support to preprocess_asm! to inject macro definitions

Additionally, add some basic tests for the rpp and rpp_procedural crates.