### PR TITLE
Re-enable fsp CI tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,8 +70,8 @@ jobs:
   - script: |
       (
         cd src/mainboard/emulation/qemu-fsp
-        echo 'NO: timeout 120s make run | tee serial'
-        echo 'NO: grep Running.payload serial'
+        timeout 120s make run | tee serial
+        grep Running.payload serial
       )
     displayName: 'Run FSP QEMU firmware in QEMU'
 - job: TestSiFiveQEMU


### PR DESCRIPTION
Update the fspsdk submodule and re-enable the FSP test in CI

When you pull this change you may need to update you submodules:
```
git submodule update --init
```