### PR TITLE
Add renode support to oreboot

### DIFF
--- a/Makefile.renode.inc
+++ b/Makefile.renode.inc
@@ -1,0 +1,6 @@
+# This Makefile is included by src/mainboards/VENDOR/BOARD/Makefile for renode
+# recipes.
+
+renode_run: mainboard
+	echo $(IMAGE)
+	$(RENODE) $(RENODE_FLAGS)

--- a/src/mainboard/sifive/hifive/Makefile
+++ b/src/mainboard/sifive/hifive/Makefile
@@ -2,8 +2,11 @@ OREBOOT=$(abspath $(CURDIR)/../../../../)
 TARGET     = riscv64imac-unknown-none-elf
 QEMU       ?= qemu-system-riscv64
 QEMU_FLAGS += -m 1g -machine sifive_u,start-in-flash=true -nographic -device loader,addr=0x20000000,file=${IMAGE} -bios none -smp 4
+RENODE       ?= renode
+RENODE_FLAGS += -e 'set bin "$(PWD)/$(ELF)" ; start @renode-release.resc'
 include ../../../../Makefile.inc
 include ../../../../Makefile.qemu.inc
+include ../../../../Makefile.renode.inc
 
 openocd:
 	$(shell which openocd) -f openocd.cfg -c "flash write_image erase unlock $(IMAGE) 0x20000000; shutdown"

--- a/src/mainboard/sifive/hifive/renode-debug.resc
+++ b/src/mainboard/sifive/hifive/renode-debug.resc
@@ -1,0 +1,24 @@
+$name?="hifive-unleashed"
+$bin?=@target/riscv64imac-unknown-none-elf/debug/hifive
+
+using sysbus
+mach create $name
+machine LoadPlatformDescription @platforms/cpus/sifive-fu540.repl
+machine LoadPlatformDescription $ORIGIN/renode-sifive-fu540.repl
+
+showAnalyzer uart0
+
+macro reset
+"""
+    sysbus LoadELF $bin
+"""
+runMacro $reset
+
+machine StartGdbServer 3333 true
+## Remember! After the connection is done and the binary is loaded, you have to issue:
+# u54_1 PC `e51 PC`
+## for every core you need to use as GDB initializes only the e51 core.
+## If you don't want the core to run, issue:
+# u54_4 IsHalted true
+
+start

--- a/src/mainboard/sifive/hifive/renode-release.resc
+++ b/src/mainboard/sifive/hifive/renode-release.resc
@@ -1,0 +1,17 @@
+$name?="hifive-unleashed"
+$bin?=@target/riscv64imac-unknown-none-elf/release/hifive
+
+using sysbus
+mach create $name
+machine LoadPlatformDescription @platforms/cpus/sifive-fu540.repl
+machine LoadPlatformDescription $ORIGIN/renode-sifive-fu540.repl
+
+showAnalyzer uart0
+
+macro reset
+"""
+    sysbus LoadELF $bin
+"""
+runMacro $reset
+
+start

--- a/src/mainboard/sifive/hifive/renode-sifive-fu540.repl
+++ b/src/mainboard/sifive/hifive/renode-sifive-fu540.repl
@@ -1,0 +1,3 @@
+// L2LIM is missing in upstream renode
+l2lim: Memory.MappedMemory @ sysbus 0x08000000
+    size: 0x02000000


### PR DESCRIPTION
Use `make run_renode` to invoke renode
Enabled for sifive unleashed board