### PR TITLE
Add some Cargo.lock files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ oreboot.asm
 target
 **/*.rs.bk
 debug.log
+
+#We only care about Cargo.lock files in src/mainboard
+Cargo.lock
+!src/mainboard/**/Cargo.lock


### PR DESCRIPTION
I find it irritating to switch branches locally but having to
repeatedly revert or stash .lock changes I didn't mean to make.

It was discussed that the ones in src/mainboard should be kept.
Any others? src/lib? src/drivers?