### PR TITLE
Makefile: use latest toolchain to install build utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ $(MAINBOARDS):
 	cd $(dir $@) && make cibuild
 
 firsttime:
-	cargo install $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
-	cargo install $(if $(STACK_SIZES_VER),--version $(STACK_SIZES_VER),) stack-sizes
+	rustup run --install nightly cargo install $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
+	rustup run --install nightly cargo install $(if $(STACK_SIZES_VER),--version $(STACK_SIZES_VER),) stack-sizes
 
 firsttime_fsp:
 	sudo apt-get install build-essential uuid-dev iasl gcc nasm python3-distutils libclang-dev


### PR DESCRIPTION
The older toolchain caused cargo-binutils to fail to compile over time.
The reason is likely that the dependencies changed.

Signed-off-by: Daniel Maslowski <info@orangecms.org>
