### PR TITLE
Add a top-level ci target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,5 +104,10 @@ $(CRATES_TO_CLIPPY):
 .PHONY: clippy $(CRATES_TO_CLIPPY)
 clippy: $(CRATES_TO_CLIPPY)
 
+# convenience target: this should be the full ci flow
+
+checkandbuildall: ciprepare clippy checkformat test mainboards
+	echo "Done CI!"
+
 clean:
 	rm -rf $(wildcard src/mainboard/*/*/target)


### PR DESCRIPTION
Now, if you have the CPU power and want to make sure it
is right, at top level you can do
make ci
if you have enough CPU,
make -j32
is quite tolerable.

Signed-off-by: Ronald Minnich <rminnich@gmail.com>