### PR TITLE
FSP: Organize UPD parameters by arch instead of board

### DIFF
--- a/src/vendorcode/fsp/coffeelake/src/lib.rs
+++ b/src/vendorcode/fsp/coffeelake/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![no_std]
+#![allow(clippy::zero_ptr)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
@@ -16,3 +17,64 @@ macro_rules! blob_macro {
 #[used]
 #[link_section = ".fspblob"]
 static FSP_BLOB: [u8; blob_macro!().len()] = *blob_macro!();
+
+pub fn get_fspm_upd() -> FSPM_UPD {
+    let mut fspm_cfg = FSP_M_CONFIG::default();
+    let mut fspm_test_cfg = FSP_M_TEST_CONFIG::default();
+
+    // These values are taken from
+    // https://github.com/coreboot/coreboot/blob/master/src/soc/intel/cannonlake/romstage/fsp_params.c#L20
+    // TODO: Fill out the remaining parameters
+    // TODO: Use constant defines for these instead of magic numbers. For example, define TsegSize
+    // as CONFIG_SMM_TSEG_SIZE. This can be defined in fsp_cfl_sys.
+    fspm_cfg.InternalGfx = 0;
+    fspm_cfg.IgdDvmt50PreAlloc = 0;
+    fspm_cfg.TsegSize = 0x800000;
+    fspm_cfg.IedSize = 0x400000;
+    fspm_cfg.SaGv = 0; // Allows memory training to happen at different frequencies? Disabled for now
+
+    fspm_test_cfg.PanelPowerEnable = 0;
+
+    FSPM_UPD {
+        FspUpdHeader: FSP_UPD_HEADER {
+            Signature: FSPM_UPD_SIGNATURE,
+            Revision: 2, // FSP 2.2
+            Reserved: [0u8; 23],
+        },
+        FspmArchUpd: FSPM_ARCH_UPD {
+            Revision: 2, // FSP 2.2
+            Reserved: [0u8; 3],
+            NvsBufferPtr: 0 as *mut core::ffi::c_void, // non-volatile storage not available
+            StackBase: 0x20000000 as *mut core::ffi::c_void, // TODO: I picked this at random
+            StackSize: 0x10000,                        // TODO: I picked this at random
+            BootLoaderTolumSize: 0, // Don't reserve "top of low usable memory" for bootloader.
+            BootMode: BOOT_WITH_FULL_CONFIGURATION,
+            Reserved1: [0u8; 8],
+        },
+        FspmConfig: fspm_cfg,
+        FspmTestConfig: fspm_test_cfg,
+        UnusedUpdSpace6: 0u8,
+        UpdTerminator: 0x55AA, // ???
+    }
+}
+
+pub fn get_fsps_upd() -> FSPS_UPD {
+    let mut fsps_config = FSP_S_CONFIG::default();
+    let fsps_test_config = FSP_S_TEST_CONFIG::default();
+
+    fsps_config.LogoSize = 0;
+    fsps_config.LogoPtr = 0;
+    fsps_config.GraphicsConfigPtr = 0;
+    fsps_config.ReservedFspsUpd = [0u8];
+
+    FSPS_UPD {
+        FspUpdHeader: FSP_UPD_HEADER {
+            Signature: FSPS_UPD_SIGNATURE,
+            Revision: 2, // FSP 2.2
+            Reserved: [0u8; 23],
+        },
+        FspsConfig: fsps_config,
+        FspsTestConfig: fsps_test_config,
+        UpdTerminator: 0x55AA, // ???
+    }
+}

--- a/src/vendorcode/fsp/qemu/src/lib.rs
+++ b/src/vendorcode/fsp/qemu/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![no_std]
+#![allow(clippy::zero_ptr)]
 
 // Rust types are used instead of generated ones.
 #[repr(C)]
@@ -22,3 +23,55 @@ macro_rules! blob_macro {
 #[used]
 #[link_section = ".fspblob"]
 static FSP_BLOB: [u8; blob_macro!().len()] = *blob_macro!();
+
+pub fn get_fspm_upd() -> FSPM_UPD {
+    FSPM_UPD {
+        FspUpdHeader: FSP_UPD_HEADER {
+            Signature: FSPM_UPD_SIGNATURE,
+            Revision: 2, // FSP 2.2
+            Reserved: [0u8; 23],
+        },
+        FspmArchUpd: FSPM_ARCH_UPD {
+            Revision: 2, // FSP 2.2
+            Reserved: [0u8; 3],
+            NvsBufferPtr: 0,        // non-volatile storage not available
+            StackBase: 0x20000000,  // TODO: I picked this at random
+            StackSize: 0x10000,     // TODO: I picked this at random
+            BootLoaderTolumSize: 0, // Don't reserve "top of low usable memory" for bootloader.
+            BootMode: BOOT_WITH_FULL_CONFIGURATION,
+            FspEventHandler: 0 as *mut FSP_EVENT_HANDLER, // optional
+            Reserved1: [0u8; 4],
+        },
+        FspmConfig: FSP_M_CONFIG {
+            SerialDebugPortAddress: 0x3f8,
+            SerialDebugPortType: 1,       // I/O
+            SerialDebugPortDevice: 3,     // External Device
+            SerialDebugPortStrideSize: 0, // 1
+            UnusedUpdSpace0: [0; 49],
+            ReservedFspmUpd: [0; 4],
+        },
+        UnusedUpdSpace1: [0u8; 2],
+        UpdTerminator: 0x55AA, // ???
+    }
+}
+
+pub fn get_fsps_upd() -> FSPS_UPD {
+    FSPS_UPD {
+        FspUpdHeader: FSP_UPD_HEADER {
+            Signature: FSPS_UPD_SIGNATURE,
+            Revision: 2, // FSP 2.2
+            Reserved: [0u8; 23],
+        },
+        UnusedUpdSpace0: [0u8; 32],
+        FspsConfig: FSP_S_CONFIG {
+            LogoSize: 0,
+            LogoPtr: 0,
+            GraphicsConfigPtr: 0,
+            PciTempResourceBase: 0,
+            UnusedUpdSpace1: [0; 32],
+            ReservedFspsUpd: 0,
+        },
+        UnusedUpdSpace2: [0u8; 13],
+        UpdTerminator: 0x55AA, // ???
+    }
+}

--- a/src/vendorcode/fsp/qemu32/src/lib.rs
+++ b/src/vendorcode/fsp/qemu32/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![no_std]
+#![allow(clippy::zero_ptr)]
 
 use uefi::EFI_GUID;
 
@@ -18,3 +19,55 @@ macro_rules! blob_macro {
 #[used]
 #[link_section = ".fspblob"]
 static FSP_BLOB: [u8; blob_macro!().len()] = *blob_macro!();
+
+pub fn get_fspm_upd() -> FSPM_UPD {
+    FSPM_UPD {
+        FspUpdHeader: FSP_UPD_HEADER {
+            Signature: FSPM_UPD_SIGNATURE,
+            Revision: 2, // FSP 2.2
+            Reserved: [0u8; 23],
+        },
+        FspmArchUpd: FSPM_ARCH_UPD {
+            Revision: 2, // FSP 2.2
+            Reserved: [0u8; 3],
+            NvsBufferPtr: 0,        // non-volatile storage not available
+            StackBase: 0x20000000,  // TODO: I picked this at random
+            StackSize: 0x10000,     // TODO: I picked this at random
+            BootLoaderTolumSize: 0, // Don't reserve "top of low usable memory" for bootloader.
+            BootMode: BOOT_WITH_FULL_CONFIGURATION,
+            FspEventHandler: 0 as *mut FSP_EVENT_HANDLER, // optional
+            Reserved1: [0u8; 4],
+        },
+        FspmConfig: FSP_M_CONFIG {
+            SerialDebugPortAddress: 0x3f8,
+            SerialDebugPortType: 1,       // I/O
+            SerialDebugPortDevice: 3,     // External Device
+            SerialDebugPortStrideSize: 0, // 1
+            UnusedUpdSpace0: [0; 49],
+            ReservedFspmUpd: [0; 4],
+        },
+        UnusedUpdSpace1: [0u8; 2],
+        UpdTerminator: 0x55AA, // ???
+    }
+}
+
+pub fn get_fsps_upd() -> FSPS_UPD {
+    FSPS_UPD {
+        FspUpdHeader: FSP_UPD_HEADER {
+            Signature: FSPS_UPD_SIGNATURE,
+            Revision: 2, // FSP 2.2
+            Reserved: [0u8; 23],
+        },
+        UnusedUpdSpace0: [0u8; 32],
+        FspsConfig: FSP_S_CONFIG {
+            LogoSize: 0,
+            LogoPtr: 0,
+            GraphicsConfigPtr: 0,
+            PciTempResourceBase: 0,
+            UnusedUpdSpace1: [0; 32],
+            ReservedFspsUpd: 0,
+        },
+        UnusedUpdSpace2: [0u8; 13],
+        UpdTerminator: 0x55AA, // ???
+    }
+}


### PR DESCRIPTION
Refactor the boards which use FSP so that the FSP UPD structures are
kept in architecture-specific crates instead of board-specific crates.
This allow boards to share the same parameters for the same CPU
generation.

Signed-off-by: Jordan Hand <jhand@google.com>