### PR TITLE
Makefile.inc: add `make fix` target for clippy fix

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -43,6 +43,9 @@ clean:
 clippy:
 	cargo clippy -- -D warnings -A clippy::write_with_newline
 
+fix:
+	cargo clippy --fix -- -D warnings -A clippy::write_with_newline
+
 # This is a temporary bandaid until clippy is fixed, for the
 # few boards that need it. To figure out which ones use it,
 # just git grep skipclippy


### PR DESCRIPTION
Signed-off-by: Daniel Maslowski <info@orangecms.org>