### PR TITLE
make clean removes more targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,4 +124,9 @@ checkandbuildall: ciprepare clippy checkformat test mainboards
 	echo "Done CI!"
 
 clean:
-	rm -rf $(wildcard src/mainboard/*/*/target)
+	rm -rf $(wildcard payloads/target) \
+	rm -rf $(wildcard tools/*/target) \
+	rm -rf $(wildcard src/*/target) \
+	rm -rf $(wildcard src/*/*/target) \
+	rm -rf $(wildcard src/*/*/*/target) \
+	rm -rf $(wildcard src/*/*/*/*/target)


### PR DESCRIPTION
rust language server (rls) spits out target/debug directories all over the place when browsing code in an IDE.
This cleans them up.