### PR TITLE
Switch to Rust 1.58.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 MAINBOARDS := $(wildcard src/mainboard/*/*/Makefile)
 
 TOOLCHAIN_VER := $(shell grep channel rust-toolchain.toml | grep -e '".*"' -o)
-BINUTILS_VER := 0.3.2
+BINUTILS_VER := 0.3.4
 STACK_SIZES_VER := 0.4.0
 
 CARGOINST := rustup run --install nightly cargo install

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-09-09"
+channel = "nightly-2021-10-21"
 components = [ "rust-src", "llvm-tools-preview", "rustfmt", "clippy" ]
 targets = [
   "aarch64-unknown-none-softfloat",

--- a/src/drivers/model/src/lib.rs
+++ b/src/drivers/model/src/lib.rs
@@ -41,7 +41,7 @@ pub trait Driver {
     /// Returns ok if `data` is empty.
     fn pread_exact(&self, mut data: &mut [u8], mut pos: usize) -> Result<()> {
         while !data.is_empty() {
-            match self.pread(&mut data, pos) {
+            match self.pread(data, pos) {
                 Ok(0) => return Err("unexpected eof"),
                 Ok(x) => {
                     data = &mut data[x..];

--- a/src/soc/amd/common/pci/src/lib.rs
+++ b/src/soc/amd/common/pci/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(const_panic)]
 
 use vcell::*;
 


### PR DESCRIPTION
- bump binutils to 0.3.4
- rust-toolchain: switch to nightly-2021-10-21
- Remove feature const_panic (stabilized)
- drivers/model: remove &mut passed to `pread`
