### PR TITLE
Remove unneeded mainboards string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,6 @@ jobs:
     - name: 'Install Dependencies'
       run: sudo apt-get update && make ciprepare
     - name: 'Build all mainboards'
-      run: make --keep-going mainboard
+      run: make --keep-going mainboards
     - name: 'Generate report of binary sizes'
       run: ./scripts/generate-size-report.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,6 @@ jobs:
     - name: 'Install Dependencies'
       run: sudo apt-get update && make ciprepare
     - name: 'Build all mainboards'
-      run: make --keep-going mainboards
+      run: make --keep-going mainboard
     - name: 'Generate report of binary sizes'
       run: ./scripts/generate-size-report.sh

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ STACK_SIZES_VER := 0.4.0
 CARGOINST := rustup run --install nightly cargo install
 
 .PHONY: $(MAINBOARDS)
-mainboard: $(MAINBOARDS)
+mainboards: $(MAINBOARDS)
 $(MAINBOARDS):
 	cd $(dir $@) && make cibuild
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ STACK_SIZES_VER := 0.4.0
 
 CARGOINST := rustup run --install nightly cargo install
 
-.PHONY: mainboards $(MAINBOARDS)
+.PHONY: $(MAINBOARDS)
 mainboard: $(MAINBOARDS)
 $(MAINBOARDS):
 	cd $(dir $@) && make cibuild


### PR DESCRIPTION
So maybe this was just confusing to me but this is how I understand the mainboard(s) target atm:
```
MAINBOARDS := $(wildcard src/mainboard/*/*/Makefile)
# ...
.PHONY: mainboards $(MAINBOARDS)
mainboard: $(MAINBOARDS)
$(MAINBOARDS):
	cd $(dir $@) && make cibuild
``` 

Even though `mainboards` (mind the s) is declared as a phony target, there is no such target. **EDIT**: _There actually is, but it is empty._
However, there is a list of targets defined through the `$(MAINBOARDS)` variable. These _are_ phony and _exist_.
The `mainboards` variable is expanded to all of the makefiles that are found at the described path (first line), so its value is something like:
`src/mainboard/aaeon/upxtreme/Makefile src/mainboard/emulation/qemu-aarch64/Makefile src/mainboard/emulation/qemu-q35/Makefile ...`

Since all of these paths are targets and are declared as phony they will always be executed when they are called. Since `mainboard` (no s) depends on `$(MAINBOARDS)` it will also always execute, irrespective of the files currently present.

Originally I was thrown off by the fact that `make mainboards` wouldn't do anything, even though I thought there was a target for it (I missunderstood the phony keyword). I feel like it would be easier to understand if that was removed.