### PR TITLE
Initialize HPET driver in DebugPort

### DIFF
--- a/src/drivers/timer/src/hpet.rs
+++ b/src/drivers/timer/src/hpet.rs
@@ -13,6 +13,7 @@
 
 use core::ops;
 
+use tock_registers::interfaces::ReadWriteable;
 use tock_registers::interfaces::Readable;
 use tock_registers::register_bitfields;
 use tock_registers::registers::{ReadOnly, ReadWrite};
@@ -80,6 +81,16 @@ impl HPET {
     /// Returns a pointer to the register block
     fn ptr(&self) -> *const RegisterBlock {
         self.base as *const _
+    }
+
+    pub fn enable(&self) -> Result<(), &str> {
+        // set enable bit for HPET timer as per 2.3.5
+        // https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/software-developers-hpet-spec-1-0a.pdf
+        self.config.modify(CONFIG::TMREN::SET);
+        match self.config.is_set(CONFIG::TMREN) {
+            true => Ok(()),
+            false => Err("HPET.enable() failed to set timer_enable."),
+        }
     }
 
     // Sleeps at least the given amount of time (in fs).

--- a/src/drivers/uart/src/debug_port.rs
+++ b/src/drivers/uart/src/debug_port.rs
@@ -20,9 +20,10 @@ impl<D: Driver> DebugPort<D> {
 }
 
 impl<D: Driver> Driver for DebugPort<D> {
-    // Nothing to set up here
     fn init(&mut self) -> Result<()> {
-        Ok(())
+        self.timer
+            .enable()
+            .map_err(|_| "DebugPort unusable: enable bit not set for HPET timer.")
     }
 
     // DebugPort can only be used to write, nothing here

--- a/src/mainboard/emulation/qemu-q35/src/main.rs
+++ b/src/mainboard/emulation/qemu-q35/src/main.rs
@@ -31,7 +31,7 @@ global_asm!(
 );
 
 #[no_mangle]
-pub extern "C" fn _start(fdt_address: usize) -> ! {
+pub extern "C" fn _start(_fdt_address: usize) -> ! {
     let uart0 = &mut I8250::new(0x3f8, 0, IOPort {});
     // Note: on real hardware, use port 0x80 instead for "POST" output
     let debug = &mut DebugPort::new(0xe9, IOPort {});


### PR DESCRIPTION
Add a function `enable()` to the HPET driver. This allows the calling driver, `DebugPort` in this case, enable the timer if it wants to use it. This is necessary for the qemu-q35 board as it does not init the timer, like the romecrb board for example.
This fixes #500.

I was contemplating whether `hpet0()` should do this automatically, but as the code is already used in other boards and there is a comment saying the caller should ensure enablement I felt like this is sensible solution. Happy to hear other opinions.