### PR TITLE
feat: introduce multi line macro in rpp 

### DIFF
--- a/tools/rpp/src/testdata/sample.S
+++ b/tools/rpp/src/testdata/sample.S
@@ -1,4 +1,5 @@
-#define MACRO 1 // Test test test
+#define MACRO \
+	(1)// Test test test
 
 #include <test.inc>
 
@@ -14,3 +15,4 @@ test:
     mov $A, %rsp
     mov $B, %rsp
     mov $C, %rsp
+				$MULTILINE_MACRO

--- a/tools/rpp/src/testdata/test.inc
+++ b/tools/rpp/src/testdata/test.inc
@@ -1,2 +1,7 @@
 #define A 2
 #define B (A+1)
+#define MULTILINE_MACRO \
+	cmp $A, $B;\
+	mov $C, %rsp;\
+ pop $rsp; // Multi-line macro ends here. This comment is ignored.
+							


### PR DESCRIPTION
#497 
This PR attempts to adds multi-line macro support in rpp. Macros like the one given below are supported now. 
```
#define MACRO \
 (A + \
  B) // This expands to (A + B)
```
Changes introduced:
 - Add `split_lines_re` Regex to `Context` struct which is used to split a line preserving escaped newlines. 
 - Add test `macro_with_newline` which checks multi-line macro expansion. 
 - The current behavior is to ignore escaped newlines while macro expansion, so multi-line macros essentially are treated as a big single-line macro. 
