### PR TITLE
Get QEMU tests up and running

### DIFF
--- a/.github/workflows/fsp-qemu.yml
+++ b/.github/workflows/fsp-qemu.yml
@@ -55,39 +55,6 @@ jobs:
           grep Running.payload serial
         )
 
-  TestSiFiveQEMU:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: 'Install Dependencies'
-      run: sudo apt-get update && make ciprepare
-    - name: 'Build SiFice QEMU firmware'
-      run: |
-        (
-          cd src/mainboard/sifive/hifive
-          PAYLOAD_A=../../../../payloads/src/external/simple/testtesttest make
-        )
-    - name: 'Build QEMU'
-      run: |
-        exit 0 # Rebuilding QEMU takes too long. Remove once we cache.
-        git clone --single-branch --branch v5.1.0 https://github.com/qemu/qemu
-        mkdir qemu/build-riscv64
-        (
-          cd qemu/build-riscv64
-          ../configure --target-list=riscv64-softmmu
-          make -j16
-          sudo ln -s $PWD/riscv64-softmmu/qemu-system-riscv64 /usr/bin/
-          sudo ln -s $PWD/qemu-img /usr/bin/
-        )
-    - name: 'Run test'
-      run: |
-        exit 0 # Rebuilding QEMU takes too long. Remove once we cache.
-        (
-          cd src/mainboard/sifive/hifive
-          PAYLOAD_A=../../../../payloads/src/external/simple/testtesttest timeout 120s make run | tee serial
-          grep TESTTESTTEST serial
-        )
-
   TestRISCVVirtBoardQEMU:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/fsp-qemu.yml
+++ b/.github/workflows/fsp-qemu.yml
@@ -74,19 +74,9 @@ jobs:
         )
     - name: 'Build QEMU'
       run: |
-        exit 0 # Rebuilding QEMU takes too long. Remove once we cache.
-        git clone --single-branch --branch v5.1.0 https://github.com/qemu/qemu
-        mkdir qemu/build-riscv64
-        (
-          cd qemu/build-riscv64
-          ../configure --target-list=riscv64-softmmu
-          make -j16
-          sudo ln -s $PWD/riscv64-softmmu/qemu-system-riscv64 /usr/bin/
-          sudo ln -s $PWD/qemu-img /usr/bin/
-        )
+        sudo apt-get install qemu-system-misc
     - name: 'Run test'
       run: |
-        exit 0 # Rebuilding QEMU takes too long. Remove once we cache.
         (
           cd src/mainboard/emulation/qemu-riscv
           timeout 30s make run | tee serial

--- a/src/soc/sifive/fu540/src/clock.rs
+++ b/src/soc/sifive/fu540/src/clock.rs
@@ -21,7 +21,6 @@ use consts::DeviceCtl;
 use core::ops;
 use model::*;
 
-use crate::is_qemu;
 use crate::reg;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use tock_registers::register_bitfields;
@@ -253,10 +252,6 @@ impl<'a> Clock<'a> {
     }
 
     fn clock_init(&mut self) {
-        if is_qemu() {
-            return;
-        }
-
         // Update the peripheral clock dividers of UART, SPI and I2C to safe
         // values as we can't put them in reset before changing frequency.
         let hfclk = 1_000_000_000; // 1GHz

--- a/src/soc/sifive/fu540/src/ddr.rs
+++ b/src/soc/sifive/fu540/src/ddr.rs
@@ -2,7 +2,6 @@ use consts::DeviceCtl;
 use core::ops;
 use model::*;
 
-use crate::is_qemu;
 use crate::reg;
 use crate::ux00;
 use core::convert::TryInto;
@@ -235,10 +234,6 @@ register_bitfields! {
 // 0
 // MASK interrupt due to cause INT_STATUS [31:0]
 fn sdram_init() {
-    if is_qemu() {
-        return;
-    }
-
     ux00::ux00ddr_writeregmap();
     ux00::ux00ddr_disableaxireadinterleave();
 
@@ -268,8 +263,5 @@ fn sdram_init() {
 }
 
 pub fn mem_size() -> u64 {
-    if is_qemu() {
-        return 1024 * 1024 * 1024;
-    }
     reg::DDR_SIZE
 }

--- a/src/soc/sifive/fu540/src/lib.rs
+++ b/src/soc/sifive/fu540/src/lib.rs
@@ -9,11 +9,3 @@ pub mod phy;
 pub mod reg;
 pub mod spi;
 pub mod ux00;
-
-use core::ptr;
-
-// TODO: There might be a better way to detect whether we are running in QEMU.
-pub fn is_qemu() -> bool {
-    // On hardware, the instruction at 0x1008 is 'lw t1, -4(t0)'.
-    unsafe { ptr::read_volatile(reg::QEMU_FLAG as *mut u32) == 0x02828613 }
-}

--- a/src/soc/starfive/jh7100/src/clock.rs
+++ b/src/soc/starfive/jh7100/src/clock.rs
@@ -42,7 +42,6 @@ use clock::ClockNode;
 //use core::ops;
 use model::*;
 
-use crate::is_qemu;
 //use crate::reg;
 use core::ptr;
 //use register::mmio::ReadWrite;
@@ -4530,10 +4529,6 @@ impl<'a> Clock<'a> {
     fn init_pll_ge(&self) {}
 
     fn clock_init(&mut self) {
-        if is_qemu() {
-            return;
-        }
-
         // Update the peripheral clock dividers of UART, SPI and I2C to safe
         // values as we can't put them in reset before changing frequency.
         let hfclk = 1_000_000_000; // 1GHz


### PR DESCRIPTION
This fixes https://github.com/oreboot/oreboot/issues/443 by getting QEMU up and running for the virt board.

We also remove the QEMU specific workarounds. The current QEMU workarounds don't work, so let's just remove them. The HiFive1 is an outdated board, not very well modelled on QEMU and is not being worked on. Instead of leaving in some old hacks let's just remove then and remove it from the CI.