### PR TITLE
fix up workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ members = [
     "payloads",
 
     "src/lib/*",
-    "src/mainboard/aaeon/*",
     "src/mainboard/amd/*",
     "src/mainboard/asrock/*",
     "src/mainboard/ast/*",


### PR DESCRIPTION
We removed the aaeon boards, so remove them from workspace members as well.

EDIT: no, that's plain wrong... I did get an error locally though. I'll check again.