### PR TITLE
Makefiles: tweak them for the new layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,4 @@ checkandbuildall: ciprepare clippy checkformat test mainboards
 	echo "Done CI!"
 
 clean:
-	rm -rf $(wildcard payloads/target) \
-	rm -rf $(wildcard tools/*/target) \
-	rm -rf $(wildcard src/*/target) \
-	rm -rf $(wildcard src/*/*/target) \
-	rm -rf $(wildcard src/*/*/*/target) \
-	rm -rf $(wildcard src/*/*/*/*/target)
+	rm -rf $(TOP)/target

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -36,9 +36,6 @@ format:
 checkformat:
 	cargo fmt -- --check
 
-clean:
-	rm -rf target/ coverall/
-
 # Clippy is the standard rule
 clippy:
 	cargo clippy -- -D warnings -A clippy::write_with_newline
@@ -61,3 +58,6 @@ skiptest:
 
 coverage:
 	cargo tarpaulin --out Lcov
+
+clean:
+	rm -rf $(TOP)/target


### PR DESCRIPTION
The location of target has changed; for all mainboards, target
is at $(TOP)/oreboot.


Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>