### PR TITLE
Nezha / D1 next

### DIFF
--- a/src/mainboard/sunxi/nezha/README.md
+++ b/src/mainboard/sunxi/nezha/README.md
@@ -53,3 +53,6 @@ using RustSBI, which is implemented here within oreboot statically.
 Set `PAYLOAD_B` for a Linux kernel and `PAYLOAD_C` for its corresponding DTB.
 The DTB (device tree blob) is built together with Linux for the respective board
 and to be found within Linux in the directory `arch/riscv/boot/dts/allwinner/`.
+
+For a WIP Linux 5.18 with kexec support, see:
+https://github.com/orangecms/linux/tree/5.18-kexec

--- a/src/mainboard/sunxi/nezha/sbi/src/execute.rs
+++ b/src/mainboard/sunxi/nezha/sbi/src/execute.rs
@@ -8,6 +8,8 @@ use core::{
 use riscv::register::scause::{Exception, Trap};
 use rustsbi::println;
 
+const DEBUG_ECALL: bool = false;
+
 pub fn execute_supervisor(supervisor_mepc: usize, a0: usize, a1: usize) -> ! {
     let mut rt = Runtime::new_sbi_supervisor(supervisor_mepc, a0, a1);
     loop {
@@ -20,6 +22,12 @@ pub fn execute_supervisor(supervisor_mepc: usize, a0: usize, a1: usize) -> ! {
                 let ans = rustsbi::ecall(ctx.a7, ctx.a6, param);
                 ctx.a0 = ans.error;
                 ctx.a1 = ans.value;
+                if DEBUG_ECALL {
+                    println!(
+                        "[rustsbi] ecall {:#04X?}/{:#04X?}, res {:#04X?}\r",
+                        ctx.a6, ctx.a7, ctx.a1
+                    );
+                }
                 ctx.mepc = ctx.mepc.wrapping_add(4);
             }
             GeneratorState::Yielded(MachineTrap::IllegalInstruction()) => {

--- a/src/mainboard/sunxi/nezha/start.S
+++ b/src/mainboard/sunxi/nezha/start.S
@@ -55,8 +55,8 @@ _boot:
     /*disable interrupt*/
     csrw mie, zero
 
-    /*enable theadisaee and maee*/
-    li t1, (0x1 << 22 | 0x1 << 21)
+    /*enable theadisaee and DO NOT SET maee (bit 21) - that'd bork Linux */
+    li t1, (0x1 << 22 | 0x0 << 21)
     csrs 0x7c0, t1     // mxstatus
 
     /*invaild ICACHE/DCACHE/BTB/BHT*/

--- a/src/soc/src/sunxi/d1/gpio.rs
+++ b/src/soc/src/sunxi/d1/gpio.rs
@@ -24,6 +24,12 @@ pub struct RegisterBlock {
     _pad2: [u32; 2],
     /* PB Pull config */
     pbpull: ReadWrite<u32, GPIO_PB_PULL::Register>,
+    _pad3: [u32; 2],
+    /* Port C Config Register 0 */
+    pccfg0: ReadWrite<u32, GPIO_PC_CFG0::Register>,
+    _pad4: [u32; 3],
+    /* PC Data Register */
+    pcdat: ReadWrite<u32, GPIO_PC_DAT::Register>,
 }
 
 pub struct GPIO {
@@ -106,7 +112,27 @@ register_bitfields! [
         PB11_PULL OFFSET(22) NUMBITS(2) [],
         PB12_PULL OFFSET(24) NUMBITS(2) []
         // 26-31: reserved
-    ]
+    ],
+    GPIO_PC_CFG0 [
+        PC0_SELECT OFFSET(0) NUMBITS(4) [],
+        PC1_SELECT OFFSET(4) NUMBITS(4) [],
+        PC2_SELECT OFFSET(8) NUMBITS(4) [],
+        PC3_SELECT OFFSET(12) NUMBITS(4) [],
+        PC4_SELECT OFFSET(16) NUMBITS(4) [],
+        PC5_SELECT OFFSET(20) NUMBITS(4) [],
+        PC6_SELECT OFFSET(24) NUMBITS(4) [],
+        PC7_SELECT OFFSET(28) NUMBITS(4) []
+    ],
+    GPIO_PC_DAT [
+        PC0_DAT OFFSET(0) NUMBITS(1) [],
+        PC1_DAT OFFSET(1) NUMBITS(1) [],
+        PC2_DAT OFFSET(2) NUMBITS(1) [],
+        PC3_DAT OFFSET(3) NUMBITS(1) [],
+        PC4_DAT OFFSET(4) NUMBITS(1) [],
+        PC5_DAT OFFSET(5) NUMBITS(1) [],
+        PC6_DAT OFFSET(6) NUMBITS(1) [],
+        PC7_DAT OFFSET(7) NUMBITS(1) [],
+    ],
 ];
 
 impl GPIO {
@@ -127,10 +153,16 @@ impl Driver for GPIO {
         // set port B GPIO5 high
         self.pbcfg0.modify(GPIO_PB_CFG0::PB5_SELECT.val(1)); // output / LED
         self.pbdat.modify(GPIO_PB_DAT::PB5_DAT.val(1)); // high
-                                                        // Config GPIOB8 and GPIOB9 to txd0 and rxd0
+
+        // set port C GPIO1 high
+        self.pccfg0.modify(GPIO_PC_CFG0::PC1_SELECT.val(1)); // output / LED
+        self.pcdat.modify(GPIO_PC_DAT::PC1_DAT.val(1)); // high
+
+        // Config GPIOB8 and GPIOB9 to txd0 and rxd0
         self.pbcfg1.modify(GPIO_PB_CFG1::PB8_SELECT.val(6)); // 0110: UART0 TX
         self.pbcfg1.modify(GPIO_PB_CFG1::PB9_SELECT.val(6)); // 0110: UART0 RX
-                                                             // enable pull-ups
+
+        // enable pull-ups
         self.pbpull.modify(GPIO_PB_PULL::PB8_PULL.val(1)); // 01: pull-up
         self.pbpull.modify(GPIO_PB_PULL::PB9_PULL.val(1)); // 01: pull-up
         Ok(())


### PR DESCRIPTION
This adds a debug helper for `ecall` (handy!), a reference to the Linux 5.18 WIP branch for the D1, disables the special `MAEE` bit for it to work, and lights up the LED on the Lichee RV module.