### PR TITLE
Fix qemu riscv dts

### DIFF
--- a/src/mainboard/emulation/qemu-riscv/fixed-dtfs.dts
+++ b/src/mainboard/emulation/qemu-riscv/fixed-dtfs.dts
@@ -11,20 +11,20 @@
         areas {
             area@0 {
                 description = "Boot Blob and Romstage";
-                offset = <0x0>;
-                size = <0x80000>; // 512KiB
+                compatible = "ore-bootblob";
+                size = <0x100000>; // 512KiB
                 file = "$(BOOTBLOB)";
             };
             area@1 {
                 description = "Fixed DTFS";
-                offset = <0x80000>;
+                compatible = "ore-dtfs";
                 size = <0x80000>; // 512KiB
                 file = "$(FIXED_DTFS)";
             };
             area@2 {
                 description = "Empty Space";
-                offset = <0x100000>;
-                size = <0x1f00000>; // 31MiB
+                offset = <0x180000>;
+                size = <0x1e80000>; // 31MiB
             };
         };
     };

--- a/src/mainboard/emulation/qemu-riscv/fixed-dtfs.dts
+++ b/src/mainboard/emulation/qemu-riscv/fixed-dtfs.dts
@@ -12,7 +12,7 @@
             area@0 {
                 description = "Boot Blob and Romstage";
                 compatible = "ore-bootblob";
-                size = <0x100000>; // 512KiB
+                size = <0x100000>; // 1MiB
                 file = "$(BOOTBLOB)";
             };
             area@1 {
@@ -24,7 +24,7 @@
             area@2 {
                 description = "Empty Space";
                 offset = <0x180000>;
-                size = <0x1e80000>; // 31MiB
+                size = <0x1e80000>; // 1.9MiB
             };
         };
     };


### PR DESCRIPTION
The oreboot binary was large enough to not fit into the flash info area as defined by the qemu-riscv `fixed-dtfs.dts` if the binary contained debug information. Only the release build did fit. As we have enough memory over, we can increase the flash and even create a bootable image for debug.