### PR TITLE
Introduce the xtask building system

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[alias]
+xtask = "run --package xtask --"
+make = "xtask make"
+asm = "xtask asm"
+flash = "xtask flash"
+# debug = "xtask debug"
+gdb = "xtask gdb"
+
+# todo: xtask qemu for emulation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ members = [
     "src/mainboard/sunxi/*",
 
     "tools/layoutflash",
+
+    "xtask",
 ]
+default-members = ["xtask"]
 
 [profile.release]
 opt-level = 'z'  # Optimize for size.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "3.1.18", features = ["derive"] }
+clap-verbosity-flag = "1.0"
+log = "0.4"
+env_logger = "0.9"
+ctrlc = "3.2"
+byteorder = "1"
+pathdiff = "0.2"

--- a/xtask/src/gdb_detect.rs
+++ b/xtask/src/gdb_detect.rs
@@ -1,0 +1,135 @@
+use log::{error, info};
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn detect_gdb_path() -> String {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let mut input = String::new();
+    println!("you need T-Head toolchain installed to debug this program.");
+    loop {
+        input.clear();
+        print!(
+            "Please input T-Head GDB toolchain path:
+> "
+        );
+        stdout.flush().unwrap();
+        stdin.read_line(&mut input).expect("read line");
+        let mut command = Command::new(&input.trim());
+        command.arg("--version");
+        let output = match command.output() {
+            Ok(output) => output,
+            Err(e) => {
+                error!("io error occurred {}", e);
+                continue;
+            }
+        };
+        let info = String::from_utf8_lossy(&output.stdout);
+        if !info.starts_with("GNU gdb") {
+            error!("not a GNU gdb program");
+            continue;
+        }
+        if info.find("Xuantie-900 elf").is_some() {
+            info!("chosen Xuantie-900 ELF GDB program");
+            break;
+        } else {
+            info!("chosen generic GDB program");
+            break;
+        }
+    }
+    input.trim().to_string()
+}
+
+pub(crate) fn detect_gdb_server(gdb_path: &str) -> String {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let mut input = String::new();
+    println!("an address is needed to connect to GDB server.");
+    loop {
+        input.clear();
+        print!(
+            "Please input GDB remote address ([host]:port):
+> "
+        );
+        stdout.flush().unwrap();
+        stdin.read_line(&mut input).expect("read line");
+        println!("trying gdb connect...");
+        let mut command = Command::new(gdb_path);
+        command.args(&["--eval-command", "set tcp connect-timeout 5"]);
+        command.args(&["--eval-command", &format!("target remote {}", input.trim())]);
+        command.arg("--batch-silent");
+        let status = match command.status() {
+            Ok(status) => status,
+            Err(e) => {
+                error!("io error occurred when trying to connect: {}", e);
+                continue;
+            }
+        };
+        if status.success() {
+            break;
+        } else {
+            error!("GDB connection error: {}", status);
+        }
+    }
+    input.trim().to_string()
+}
+
+pub fn save_gdb_path_to_file(gdb_path: &str) {
+    fs::create_dir_all(project_root().join("target").join("xtask")).expect("create folder");
+    let mut file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(
+            project_root()
+                .join("target")
+                .join("xtask")
+                .join("gdb-path.txt"),
+        )
+        .expect("create and open file");
+    file.write(gdb_path.as_bytes()).expect("write file");
+}
+
+pub fn load_gdb_path_from_file() -> io::Result<String> {
+    fs::read_to_string(
+        project_root()
+            .join("target")
+            .join("xtask")
+            .join("gdb-path.txt"),
+    )
+}
+
+pub fn save_gdb_server_to_file(gdb_server: &str) {
+    fs::create_dir_all(project_root().join("target").join("xtask")).expect("create folder");
+    let mut file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(
+            project_root()
+                .join("target")
+                .join("xtask")
+                .join("gdb-server.txt"),
+        )
+        .expect("create and open file");
+    file.write(gdb_server.as_bytes()).expect("write file");
+}
+
+pub fn load_gdb_server_from_file() -> io::Result<String> {
+    fs::read_to_string(
+        project_root()
+            .join("target")
+            .join("xtask")
+            .join("gdb-server.txt"),
+    )
+}
+
+fn project_root() -> PathBuf {
+    Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .unwrap()
+        .to_path_buf()
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,115 @@
+mod gdb_detect;
+mod target;
+
+mod sunxi;
+
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process,
+    str::FromStr,
+};
+
+use clap::{Args, Parser, Subcommand};
+use clap_verbosity_flag::Verbosity;
+use log::error;
+
+#[derive(Parser)]
+#[clap(name = "xtask")]
+#[clap(about = "Program that help you build and debug Oreboot project", long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+    #[clap(flatten)]
+    env: Env,
+    #[clap(flatten)]
+    verbose: Verbosity,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Make this project
+    Make,
+    /// Build flash and burn into target
+    Flash,
+    /// View assembly code
+    Asm,
+    /// Debug code using gdb
+    Gdb,
+}
+
+enum Memory {
+    /// Operate on NAND flash
+    Nand,
+    /// Operate on NOR flash
+    Nor,
+}
+
+impl FromStr for Memory {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "nand" => Ok(Self::Nand),
+            "nor" => Ok(Self::Nor),
+            others => Err(format!("unknown memory type {}", others)),
+        }
+    }
+}
+
+#[derive(Args)]
+struct Env {
+    #[clap(
+        long = "release",
+        global = true,
+        help = "Build in release mode",
+        long_help = None,
+    )]
+    release: bool,
+    #[clap(long, global = true, help = "Mainboard to build")]
+    mainboard: Option<String>,
+    #[clap(long, global = true, help = "Target memory description")]
+    memory: Option<Memory>,
+    #[clap(long, global = true, help = "Board variant")]
+    variant: Option<String>,
+}
+
+fn main() {
+    let args = Cli::parse();
+    env_logger::Builder::new()
+        .filter_level(args.verbose.log_level_filter())
+        .init();
+    let cur_path = env::current_dir().unwrap();
+    let target = if let Some(target) = target::parse_target(
+        &cur_path,
+        args.env.mainboard.as_deref(),
+        args.env.variant.as_deref(),
+    ) {
+        target
+    } else {
+        error!(
+            "can't decide target for task
+    Change directory to mainboard and run again, or
+    use `--mainboard <VENDOR/BOARD>` and `--variant <VARIANT>` when necessary."
+        );
+        process::exit(1)
+    };
+    target.execute_command(&args);
+}
+
+fn dist_dir(env: &Env, target: &str) -> PathBuf {
+    let mut path_buf = project_root().join("target").join(target);
+    path_buf = match env.release {
+        false => path_buf.join("debug"),
+        true => path_buf.join("release"),
+    };
+    path_buf
+}
+
+fn project_root() -> PathBuf {
+    Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .unwrap()
+        .to_path_buf()
+}

--- a/xtask/src/sunxi/mod.rs
+++ b/xtask/src/sunxi/mod.rs
@@ -1,0 +1,15 @@
+mod nezha;
+use super::Cli;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Board {
+    Nezha,
+}
+
+impl Board {
+    pub(crate) fn execute_command(self, command: &Cli, features: Vec<String>) {
+        match self {
+            Board::Nezha => nezha::execute_command(command, features),
+        };
+    }
+}

--- a/xtask/src/sunxi/nezha.rs
+++ b/xtask/src/sunxi/nezha.rs
@@ -1,0 +1,357 @@
+use crate::dist_dir;
+use crate::gdb_detect;
+use crate::project_root;
+use crate::{Commands, Env, Memory};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use log::{error, info, trace};
+use std::env;
+use std::fs::File;
+use std::io::{self, ErrorKind, Seek, SeekFrom};
+use std::process::{self, Command, Stdio};
+
+pub(crate) fn execute_command(args: &crate::Cli, features: Vec<String>) {
+    match args.command {
+        Commands::Make => {
+            info!("make D1 flash binary");
+            let binutils_prefix = find_binutils_prefix_or_fail();
+            xtask_build_d1_flash_bt0(&args.env, &features);
+            xtask_build_d1_flash_main(&args.env);
+            xtask_binary_d1_flash_bt0(binutils_prefix, &args.env);
+            xtask_binary_d1_flash_main(binutils_prefix, &args.env);
+            xtask_finialize_d1_flash(&args.env);
+            xtask_concat_flash_binaries(&args.env);
+        }
+        Commands::Flash => {
+            info!("build D1 binary and burn");
+            let xfel = find_xfel();
+            xfel_find_connected_device(xfel);
+            let binutils_prefix = find_binutils_prefix_or_fail();
+            xtask_build_d1_flash_bt0(&args.env, &features);
+            xtask_build_d1_flash_main(&args.env);
+            xtask_binary_d1_flash_bt0(binutils_prefix, &args.env);
+            xtask_binary_d1_flash_main(binutils_prefix, &args.env);
+            xtask_finialize_d1_flash(&args.env);
+            xtask_concat_flash_binaries(&args.env);
+            xtask_burn_d1_flash_bt0(xfel, &args.env);
+        }
+        Commands::Asm => {
+            info!("build D1 flash ELF and view assembly");
+            let binutils_prefix = find_binutils_prefix_or_fail();
+            xtask_build_d1_flash_bt0(&args.env, &features);
+            xtask_dump_d1_flash_bt0(binutils_prefix, &args.env);
+        }
+        Commands::Gdb => {
+            info!("debug using gdb");
+            xtask_build_d1_flash_bt0(&args.env, &features);
+            let gdb_path = if let Ok(ans) = gdb_detect::load_gdb_path_from_file() {
+                ans
+            } else {
+                let ans = gdb_detect::detect_gdb_path();
+                gdb_detect::save_gdb_path_to_file(&ans);
+                trace!("saved GDB path");
+                ans
+            };
+            let gdb_server = if let Ok(ans) = gdb_detect::load_gdb_server_from_file() {
+                ans
+            } else {
+                let ans = gdb_detect::detect_gdb_server(&gdb_path);
+                gdb_detect::save_gdb_server_to_file(&ans);
+                trace!("saved GDB server");
+                ans
+            };
+            xtask_debug_gdb(&gdb_path, &gdb_server, &args.env);
+        }
+    }
+}
+
+const DEFAULT_TARGET: &'static str = "riscv64imac-unknown-none-elf";
+
+fn xtask_build_d1_flash_bt0(env: &Env, features: &Vec<String>) {
+    trace!("build D1 flash bt0");
+    let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    trace!("found cargo at {}", cargo);
+    let mut command = Command::new(cargo);
+    command.current_dir(board_project_root().join("bt0"));
+    command.arg("build");
+    if env.release {
+        command.arg("--release");
+    }
+    if features.len() != 0 {
+        let command_line_features = features.join(",");
+        trace!("append command line features: {}", command_line_features);
+        command.arg("--no-default-features");
+        command.args(&["--features", &command_line_features]);
+    } else {
+        trace!("no command line features appended");
+    }
+    let status = command.status().unwrap();
+    trace!("cargo returned {}", status);
+    if !status.success() {
+        error!("cargo build failed with {}", status);
+        process::exit(1);
+    }
+}
+
+fn xtask_build_d1_flash_main(env: &Env) {
+    trace!("build D1 flash main");
+    let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    trace!("found cargo at {}", cargo);
+    let mut command = Command::new(cargo);
+    command.current_dir(board_project_root().join("main"));
+    command.arg("build");
+    if env.release {
+        command.arg("--release");
+    }
+    let status = command.status().unwrap();
+    trace!("cargo returned {}", status);
+    if !status.success() {
+        error!("cargo build failed with {}", status);
+        process::exit(1);
+    }
+}
+
+fn xtask_binary_d1_flash_bt0(prefix: &str, env: &Env) {
+    trace!("objcopy binary, prefix: '{}'", prefix);
+    let status = Command::new(format!("{}objcopy", prefix))
+        .current_dir(dist_dir(env, DEFAULT_TARGET))
+        .arg("oreboot-nezha-bt0")
+        .arg("--binary-architecture=riscv64")
+        .arg("--strip-all")
+        .args(&["-O", "binary", "oreboot-nezha-bt0.bin"])
+        .status()
+        .unwrap();
+
+    trace!("objcopy returned {}", status);
+    if !status.success() {
+        error!("objcopy failed with {}", status);
+        process::exit(1);
+    }
+}
+
+fn xtask_binary_d1_flash_main(prefix: &str, env: &Env) {
+    trace!("objcopy binary, prefix: '{}'", prefix);
+    let status = Command::new(format!("{}objcopy", prefix))
+        .current_dir(dist_dir(env, DEFAULT_TARGET))
+        .arg("oreboot-nezha-main")
+        .arg("--binary-architecture=riscv64")
+        .arg("--strip-all")
+        .args(&["-O", "binary", "oreboot-nezha-main.bin"])
+        .status()
+        .unwrap();
+
+    trace!("objcopy returned {}", status);
+    if !status.success() {
+        error!("objcopy failed with {}", status);
+        process::exit(1);
+    }
+}
+
+const EGON_HEAD_LENGTH: u64 = 0x60;
+const MAIN_STAGE_HEAD_LENGTH: u64 = 0x08;
+const TOTAL_HEAD_LENGTH: u64 = EGON_HEAD_LENGTH + MAIN_STAGE_HEAD_LENGTH;
+
+// This function does:
+// 1. fill in binary length of bt0
+// 2. fill in flash length of main stage
+// 3. calculate checksum of bt0 image; old checksum value must be filled as stamp value
+fn xtask_finialize_d1_flash(env: &Env) {
+    let path = dist_dir(env, DEFAULT_TARGET);
+    let mut bt0_file = File::options()
+        .read(true)
+        .write(true)
+        .open(path.join("oreboot-nezha-bt0.bin"))
+        .expect("open output binary file");
+    let total_length = bt0_file.metadata().unwrap().len();
+    if total_length < TOTAL_HEAD_LENGTH {
+        error!(
+            "objcopy binary size less than minimal header length, expected >= {} but is {}",
+            TOTAL_HEAD_LENGTH, total_length
+        );
+    }
+    let main_stage_file = File::options()
+        .read(true)
+        .write(true)
+        .open(path.join("oreboot-nezha-main.bin"))
+        .expect("open output binary file");
+    let main_stage_length = main_stage_file.metadata().unwrap().len();
+    bt0_file.seek(SeekFrom::Start(0x64)).unwrap();
+    bt0_file
+        .write_u32::<LittleEndian>(main_stage_length as u32)
+        .unwrap();
+    let new_len = align_up_to(total_length, 16 * 1024); // align up to 16KB
+    bt0_file.seek(SeekFrom::Start(0x60)).unwrap();
+    bt0_file.write_u32::<LittleEndian>(new_len as u32).unwrap();
+    bt0_file.set_len(new_len).unwrap();
+    bt0_file.seek(SeekFrom::Start(0x10)).unwrap();
+    bt0_file.write_u32::<LittleEndian>(new_len as u32).unwrap();
+    bt0_file.seek(SeekFrom::Start(0x0C)).unwrap();
+    let stamp = bt0_file.read_u32::<LittleEndian>().unwrap();
+    if stamp != 0x5F0A6C39 {
+        error!("wrong stamp value; check your generated blob and try again")
+    }
+    let mut checksum: u32 = 0;
+    bt0_file.seek(SeekFrom::Start(0)).unwrap();
+    loop {
+        match bt0_file.read_u32::<LittleEndian>() {
+            Ok(val) => checksum = checksum.wrapping_add(val),
+            Err(e) if e.kind() == ErrorKind::UnexpectedEof => break,
+            Err(e) => error!("io error while calculating checksum: {:?}", e),
+        }
+    }
+    bt0_file.seek(SeekFrom::Start(0x0C)).unwrap();
+    bt0_file.write_u32::<LittleEndian>(checksum).unwrap();
+    bt0_file.sync_all().unwrap(); // save file before automatic closing
+} // for C developers: files are automatically closed when they're out of scope
+
+fn align_up_to(len: u64, target_align: u64) -> u64 {
+    let (div, rem) = (len / target_align, len % target_align);
+    if rem != 0 {
+        (div + 1) * target_align
+    } else {
+        len
+    }
+}
+
+fn xtask_concat_flash_binaries(env: &Env) {
+    let dist_dir = dist_dir(env, DEFAULT_TARGET);
+    let mut bt0_file = File::options()
+        .read(true)
+        .open(dist_dir.join("oreboot-nezha-bt0.bin"))
+        .expect("open bt0 binary file");
+    let mut main_file = File::options()
+        .read(true)
+        .open(dist_dir.join("oreboot-nezha-main.bin"))
+        .expect("open main binary file");
+    let mut output_file = File::options()
+        .write(true)
+        .create(true)
+        .open(dist_dir.join("oreboot-nezha.bin"))
+        .expect("create output binary file");
+    let bt0_len = bt0_file.metadata().unwrap().len();
+    let new_len = bt0_len + main_file.metadata().unwrap().len();
+    output_file.set_len(new_len).unwrap();
+    io::copy(&mut bt0_file, &mut output_file).expect("copy bt0 binary");
+    output_file
+        .seek(SeekFrom::Start(bt0_len))
+        .expect("seek after bt0 copy");
+    io::copy(&mut main_file, &mut output_file).expect("copy main binary");
+}
+
+fn xtask_burn_d1_flash_bt0(xfel: &str, env: &Env) {
+    trace!("burn flash with xfel {}", xfel);
+    let mut command = Command::new(xfel);
+    command.current_dir(dist_dir(env, DEFAULT_TARGET));
+    match env.memory {
+        Some(Memory::Nand) => command.arg("spinand"),
+        Some(Memory::Nor) => command.arg("spinor"),
+        None => {
+            error!("no memory parameter found; use --memory nand or --memory nor");
+            process::exit(1);
+        }
+    };
+    command.args(["write", "0"]);
+    command.arg("oreboot-nezha.bin");
+    let status = command.status().unwrap();
+    trace!("xfel returned {}", status);
+    if !status.success() {
+        error!("xfel failed with {}", status);
+        process::exit(1);
+    }
+}
+
+fn xtask_dump_d1_flash_bt0(prefix: &str, env: &Env) {
+    Command::new(format!("{}objdump", prefix))
+        .current_dir(dist_dir(env, DEFAULT_TARGET))
+        .arg("oreboot-nezha-bt0")
+        .arg("-d")
+        .status()
+        .unwrap();
+}
+
+fn xtask_debug_gdb(gdb_path: &str, gdb_server: &str, env: &Env) {
+    let mut command = Command::new(gdb_path);
+    command.current_dir(dist_dir(env, DEFAULT_TARGET));
+    command.args(&["--eval-command", "file oreboot-nezha-bt0"]);
+    command.args(&["--eval-command", "set architecture riscv:rv64"]);
+    command.args(&["--eval-command", "mem 0x0 0xffff ro"]);
+    command.args(&["--eval-command", "mem 0x20000 0x27fff rw"]);
+    command.args(&["--eval-command", &format!("target remote {}", gdb_server)]);
+    command.arg("-q");
+    ctrlc::set_handler(move || {
+        // when ctrl-c, don't exit gdb
+    })
+    .expect("disable Ctrl-C exit");
+    let status = command.status().unwrap();
+    if !status.success() {
+        error!("gdb failed with {}", status);
+        process::exit(1);
+    }
+}
+
+fn find_xfel() -> &'static str {
+    let mut command = Command::new("xfel");
+    command.stdout(Stdio::null());
+    match command.status() {
+        Ok(status) if status.success() => return "xfel",
+        Ok(status) => match status.code() {
+            Some(code) => {
+                error!("xfel command failed with code {}", code);
+                process::exit(code)
+            }
+            None => error!("xfel command terminated by signal"),
+        },
+        Err(e) if e.kind() == ErrorKind::NotFound => error!(
+            "xfel not found
+    install xfel from: https://github.com/xboot/xfel"
+        ),
+        Err(e) => error!(
+            "I/O error occurred when detecting xfel: {}.
+    Please check your xfel program and try again.",
+            e
+        ),
+    }
+    process::exit(1)
+}
+
+fn xfel_find_connected_device(xfel: &str) {
+    let mut command = Command::new(xfel);
+    command.arg("version");
+    let output = command.output().unwrap();
+    if !output.status.success() {
+        error!("xfel failed with code {}", output.status);
+        error!("Is your device in FEL mode?");
+        process::exit(1);
+    }
+    info!("Found {}", String::from_utf8_lossy(&output.stdout).trim());
+}
+
+fn find_binutils_prefix() -> Option<&'static str> {
+    for prefix in ["rust-", "riscv64-unknown-elf-", "riscv64-linux-gnu-"] {
+        let mut command = Command::new(format!("{}objcopy", prefix));
+        command.arg("--version");
+        command.stdout(Stdio::null());
+        let status = command.status().unwrap();
+        if status.success() {
+            return Some(prefix);
+        }
+    }
+    None
+}
+
+fn find_binutils_prefix_or_fail() -> &'static str {
+    trace!("find binutils");
+    if let Some(ans) = find_binutils_prefix() {
+        trace!("found binutils, prefix is '{}'", ans);
+        return ans;
+    }
+    error!(
+        "no binutils found, try install using:
+    rustup component add llvm-tools-preview
+    cargo install cargo-binutils"
+    );
+    process::exit(1)
+}
+
+fn board_project_root() -> std::path::PathBuf {
+    project_root().join("src/mainboard/sunxi/nezha")
+}

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -1,0 +1,136 @@
+use crate::project_root;
+use log::{error, trace};
+use std::path::{Component, Path};
+
+use crate::sunxi;
+
+pub(crate) struct Target {
+    vendor_board: Vendor,
+    features: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Vendor {
+    Sunxi(crate::sunxi::Board),
+}
+
+impl Target {
+    pub(crate) fn execute_command(self, command: &crate::Cli) {
+        match self.vendor_board {
+            Vendor::Sunxi(sunxi) => sunxi.execute_command(command, self.features),
+        };
+    }
+}
+
+pub(crate) fn parse_target(
+    cur_path: &Path,
+    param_mainboard: Option<&str>,
+    param_variant: Option<&str>,
+) -> Option<Target> {
+    let features_from_variant = if let Some(variant) = param_variant {
+        vec![variant.to_string()]
+    } else {
+        vec![]
+    };
+    if let Some((vendor, board)) = parse_target_str(cur_path, param_mainboard) {
+        let vendor_board = match (vendor.as_ref(), board.as_ref()) {
+            ("sunxi", "nezha") => Vendor::Sunxi(sunxi::Board::Nezha),
+            _ => return None,
+        };
+        return Some(Target {
+            vendor_board,
+            features: features_from_variant,
+        });
+    };
+    None
+}
+
+// mainboard format: vendor/board
+fn parse_target_str(cur_path: &Path, param_mainboard: Option<&str>) -> Option<(String, String)> {
+    trace!("parse target string, mainboard: {:?}", param_mainboard);
+    if let Some(mainboard_str) = param_mainboard {
+        trace!("try parse from parameter mainboard: {:?}", mainboard_str);
+        let mut split = mainboard_str.split('/');
+        let vendor = if let Some(vendor) = split.next() {
+            vendor
+        } else {
+            trace!("no input vendor");
+            return None;
+        };
+        let board = if let Some(board) = split.next() {
+            board
+        } else {
+            trace!("no input board");
+            return None;
+        };
+        if split.next() != None {
+            trace!("there is unexpected remaining string");
+            return None;
+        }
+        let input_mainboard_path = project_root()
+            .join("src")
+            .join("mainboard")
+            .join(vendor)
+            .join(board);
+        if !input_mainboard_path.exists() {
+            trace!("path not exist");
+            return None;
+        }
+        return Some((vendor.to_string(), board.to_string()));
+    }
+    let relative_path = match pathdiff::diff_paths(cur_path, project_root()) {
+        Some(path_buf) => path_buf,
+        None => {
+            error!("project root is relative, this is unreachable");
+            return None;
+        }
+    };
+    trace!("current relative path: {:?}", relative_path);
+    let mainboard_base_path = Path::new("src/mainboard");
+    // note(unwrap): both paths are relative
+    let mainboard = pathdiff::diff_paths(relative_path, mainboard_base_path).unwrap();
+    trace!("path diff to mainboard folder: {:?}", mainboard);
+    let mut components = mainboard.components();
+    let vendor_board_from_path = match components.next() {
+        Some(Component::Normal(vendor)) => {
+            trace!("vendor from path: {:?}", vendor);
+            match components.next() {
+                Some(Component::Normal(board)) => {
+                    trace!("board from path: {:?}", board);
+                    Some((vendor, board))
+                }
+                Some(Component::ParentDir | Component::CurDir) => {
+                    trace!("when reading path, not in any subfolder of mainboard folder");
+                    None
+                }
+                None => {
+                    trace!("can't decide board from this path");
+                    None
+                }
+                illegal @ Some(Component::Prefix(_) | Component::RootDir) => {
+                    trace!("illegal path diffs: {:?}", illegal);
+                    unreachable!()
+                }
+            }
+        }
+        Some(Component::ParentDir | Component::CurDir) => {
+            trace!("when reading vendor, not in any subfolder of mainboard folder");
+            None
+        }
+        None => {
+            trace!("can't decide vendor from this path");
+            None
+        }
+        illegal @ Some(Component::Prefix(_) | Component::RootDir) => {
+            trace!("illegal path diffs: {:?}", illegal);
+            unreachable!()
+        }
+    };
+    if let Some((vendor, board)) = vendor_board_from_path {
+        return Some((
+            vendor.to_string_lossy().to_string(),
+            board.to_string_lossy().to_string(),
+        ));
+    }
+    None
+}


### PR DESCRIPTION
This pull request is a successor to #555, it introduces the `xtask` building system into Oreboot project. The xtask system provides an easy way to build, flash and debug Oreboot with more host platforms (like Windows). The Makefile build system is still kept for compatibility.

To use `xtask` build system, you may execute the following commands:

* cargo make
* cargo flash
* cargo gdb
* cargo asm

... to build image, flash, debug or view assembly code on Oreboot platforms.

On each command, we change directory in `src/mainboard/<vendor>/<board>` or use `--mainboard` to decide which board we need to build to, `--variant` to choose the type of target board, and use `--release` to build under release profile. Parameter `--verbose` would print verbose output message to allow us to debug xtask itself.

The xtask system currently supports sunxi/nezha platform which has not upstreamed yet. Use command `cargo run`, we run xtask to view a list of commands we may use.

Xtask system may also to expanded to run emulators within command line, this feature is reserved in current commit to allow future implementation on different emulation mainboards.