### PR TITLE
sunxi/nezha: non-SBI support

### DIFF
--- a/src/mainboard/sunxi/nezha/Makefile
+++ b/src/mainboard/sunxi/nezha/Makefile
@@ -27,21 +27,31 @@ citest: nop
 checkformat: nop
 
 mainboard:
-	cargo make $(RELEASE) --variant $(VARIANT) --memory $(MEMORY)
+	cargo make $(RELEASE) --variant $(VARIANT) --memory $(MEMORY) --supervisor
 
 withpayload:
 	cargo make $(RELEASE) --variant $(VARIANT) --memory $(MEMORY) \
-		--payload $(PAYLOAD) --dtb $(DTB)
+		--supervisor --payload $(PAYLOAD) --dtb $(DTB)
+
+nosbi:
+	cargo make $(RELEASE) --variant $(VARIANT) --memory $(MEMORY)
 
 flash:
+	cargo flash $(RELEASE) --variant $(VARIANT) --memory $(MEMORY) --supervisor
+
+nosbiflash:
 	cargo flash $(RELEASE) --variant $(VARIANT) --memory $(MEMORY)
 
 flashwithpayload:
 	cargo flash $(RELEASE) --variant $(VARIANT) --memory $(MEMORY) \
-		--payload $(PAYLOAD) --dtb $(DTB)
+		--supervisor --payload $(PAYLOAD) --dtb $(DTB)
+
+nosbiflashwithpayload:
+	cargo flash $(RELEASE) --variant $(VARIANT) --memory $(MEMORY) \
+		--payload $(PAYLOAD)
 
 objdump:
-	cargo asm --variant $(VARIANT) --memory $(MEMORY)
+	cargo asm --variant $(VARIANT) --memory $(MEMORY) --supervisor
 
 raminitandboot:
 	$(XFEL) ddr d1

--- a/src/mainboard/sunxi/nezha/bt0/src/main.rs
+++ b/src/mainboard/sunxi/nezha/bt0/src/main.rs
@@ -309,6 +309,8 @@ fn load(
 ) {
     let chunks = 16;
     let sz = size >> 2;
+    // println!("load {:x} bytes from {:x} to {:x}", size, skip, base);
+    print!("load {:08x} bytes to {:x}: ", size, base);
     for i in 0..sz / chunks {
         let off = skip + i * 4 * chunks;
         let buf = f.copy_into([(off >> 16) as u8, (off >> 8) as u8, off as u8]);

--- a/src/mainboard/sunxi/nezha/compression/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/compression/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "oreboot_compression"
+version = "0.1.0"
+authors = ["oreboot authors"]
+edition = "2021"
+
+[dependencies]
+lzss = { version = "0.8", default-features = false }

--- a/src/mainboard/sunxi/nezha/compression/src/lib.rs
+++ b/src/mainboard/sunxi/nezha/compression/src/lib.rs
@@ -1,0 +1,37 @@
+#![no_std]
+
+use core::{fmt::Write, ptr::read_volatile, slice};
+
+const EI: usize = 12;
+type MyLzss = lzss::Lzss<EI, 4, 0x00, { 1 << EI }, { 2 << EI }>;
+
+pub fn decompress(
+    mut w: impl Write,
+    compressed_addr: usize,
+    target_addr: usize,
+    payload_size: usize,
+) {
+    // first four bytes are the compressed size
+    let in_ptr = (compressed_addr + 4) as *const u8;
+    let out_ptr = target_addr as *mut u8;
+    let compressed_size = unsafe { read_volatile(compressed_addr as *const u32) };
+    write!(
+        w,
+        "Decompress {} bytes from {:?} to {:?}, reserved {:?} bytes\n",
+        compressed_size, &in_ptr, &out_ptr, payload_size
+    )
+    .ok();
+
+    let input = unsafe { slice::from_raw_parts(in_ptr, compressed_size as usize) };
+    let output = unsafe { slice::from_raw_parts_mut(out_ptr, payload_size) };
+
+    let result = MyLzss::decompress(
+        lzss::SliceReader::new(input),
+        lzss::SliceWriter::new(output),
+    );
+    match result {
+        Ok(r) => write!(w, "Success, decompressed {r} bytes :)\n"),
+        Err(e) => write!(w, "Decompression error {e}\n"),
+    }
+    .ok();
+}

--- a/src/mainboard/sunxi/nezha/main/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/main/Cargo.toml
@@ -10,14 +10,22 @@ bitflags = "1"
 buddy_system_allocator = "0.8"
 embedded-hal = "=1.0.0-alpha.8"
 lazy_static = { version = "1", features = ["spin_no_std"] }
-lzss = { version = "0.8", default-features = false }
 nb = "1"
 riscv = "0.9.0"
+# rustsbi = { path = "../rustsbi", features =["legacy"] }
 rustsbi = { version = "=0.3.0-alpha.4", features = ["legacy"] }
+sbi-spec = "0.0.2"
 # todo: a new package oreboot-console
 spin = "0.9" # todo: remove when we have a console package
 vcell = "0.1.3"
 
+[dependencies.oreboot_compression]
+path = "../compression"
+
 [dependencies.oreboot-soc]
 path = "../../../../soc"
 features = ["sunxi_d1"]
+
+[features]
+default = []
+supervisor = []

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -66,6 +66,13 @@ struct Env {
         long_help = None,
     )]
     release: bool,
+    #[clap(
+        long = "supervisor",
+        global = true,
+        help = "Build with arch-specific supervisor support",
+        long_help = None,
+    )]
+    supervisor: bool,
     #[clap(long, global = true, help = "Mainboard to build")]
     mainboard: Option<String>,
     #[clap(long, global = true, help = "Target memory description")]


### PR DESCRIPTION
This expands the make targets in a manner I don't like _that_ much.
It works though, tried MnemOS and xv6:

```
make nosbiflashwithpayload \
PAYLOAD=~/firmware/Allwinner/D1/xv6-d1/kernel/kernel.bin
```

xv6 may have some assumptions not fulfilled by oreboot yet. At least it says it's booting up and echoes back keyboard input. MnemOS boots up fine.