### PR TITLE
Lock deps to fix build

### DIFF
--- a/src/mainboard/sunxi/nezha/bt0/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/bt0/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-hal = "1.0.0-alpha.8"
+embedded-hal = "=1.0.0-alpha.8"
 nb = "1"
 spin = "0.9"
 ufmt = "0.1"

--- a/src/mainboard/sunxi/nezha/main/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/main/Cargo.toml
@@ -7,14 +7,12 @@ edition = "2021"
 
 [dependencies]
 nb = "1"
-# rustsbi = { path = "../rustsbi", features =["legacy"] }
-# rustsbi = { version = "=0.3.0-alpha.2", features = ["legacy"] }
-rustsbi = { git = "https://github.com/rustsbi/rustsbi", commit = "b468de3", features = ["legacy"] }
+rustsbi = { version = "=0.3.0-alpha.4", features = ["legacy"] }
 bitflags = "1"
 buddy_system_allocator = "0.8"
 lazy_static = { version = "1", features = ["spin_no_std"] }
-riscv = { git = "https://github.com/rust-embedded/riscv", commit = "e38a68d" }
-embedded-hal = "1.0.0-alpha.8"
+riscv = "0.9.0"
+embedded-hal = "=1.0.0-alpha.8"
 vcell = "0.1.3"
 lzss = { version = "0.8", default-features = false }
 # todo: a new package oreboot-console


### PR DESCRIPTION
Seemingly, "commit" never worked. This explains the current broken build.
    
This also fixes cargo warning unused manifest key "commit".

Example warning:

```
warning: src/mainboard/sunxi/nezha/main/Cargo.toml: unused manifest key: dependencies.riscv.commit
warning: src/mainboard/sunxi/nezha/main/Cargo.toml: unused manifest key: dependencies.rustsbi.commit
```

Signed-off-by: Ben Werthmann <ben.werthmann@gmail.com>