### PR TITLE
oreboot-nezha-bt0: rustdoc: clickable U-Boot link

### DIFF
--- a/src/mainboard/sunxi/nezha/bt0/src/main.rs
+++ b/src/mainboard/sunxi/nezha/bt0/src/main.rs
@@ -247,7 +247,7 @@ This bit will be reset to 1’b0.
 /// It allows for configuring special eXtensions. See further below for details.
 ///
 /// See also what mainline U-Boot does
-/// https://github.com/smaeul/u-boot/blob/55103cc657a4a84eabc9ae2dabfcab149b07934f/board/sunxi/board-riscv.c#L72-L75
+/// <https://github.com/smaeul/u-boot/blob/55103cc657a4a84eabc9ae2dabfcab149b07934f/board/sunxi/board-riscv.c#L72-L75>
 #[naked]
 #[export_name = "start"]
 #[link_section = ".text.entry"]


### PR DESCRIPTION
Run `cargo doc --all-features --document-private-items`

```
Documenting oreboot-nezha-bt0 v0.1.0 (./src/mainboard/sunxi/nezha/bt0)
warning: this URL is not a hyperlink
   --> src/mainboard/sunxi/nezha/bt0/src/main.rs:250:5
    |
250 | /// https://github.com/smaeul/u-boot/blob/55103cc657a4a84eabc9ae2dabfcab149b07934f/board/sunxi/board-riscv.c#L72-L75
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/smaeul/u-boot/blob/55103cc657a4a84eabc9ae2dabfcab149b07934f/board/sunxi/board-riscv.c#L72-L75>`
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `#[warn(rustdoc::bare_urls)]` on by default
```

Signed-off-by: Ben Werthmann <ben.werthmann@gmail.com>