### PR TITLE
oreboot-nezha-bt0: toml-fmt cargo manifest

### DIFF
--- a/src/mainboard/sunxi/nezha/bt0/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/bt0/Cargo.toml
@@ -1,30 +1,26 @@
 [package]
-name = "oreboot-nezha-bt0"
-version = "0.1.0"
-edition = "2021"
+name = 'oreboot-nezha-bt0'
+version = '0.1.0'
+edition = '2021'
 authors = [
-    "Luo Jia <me@luojia.cc>",
-    "Daniel Maslowski <info@orangecms.org>",
-    "YdrMaster <ydrml@hotmail.com>",
+    'Luo Jia <me@luojia.cc>',
+    'Daniel Maslowski <info@orangecms.org>',
+    'YdrMaster <ydrml@hotmail.com>',
 ]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-embedded-hal = "=1.0.0-alpha.8"
-nb = "1"
-spin = "0.9"
-ufmt = "0.1"
+embedded-hal = '=1.0.0-alpha.8'
+nb = '1'
+spin = '0.9'
+ufmt = '0.1'
 
 [dependencies.oreboot-soc]
-path = "../../../../soc"
-features = ["sunxi_d1"]
+path = '../../../../soc'
+features = ['sunxi_d1']
 
 [features]
-default = ["nezha"]
-
-nezha = ["nand"]
-lichee = ["nor"]
-
+default = ['nezha']
+nezha = ['nand']
+lichee = ['nor']
 nand = []
 nor = []


### PR DESCRIPTION
1. Run `cargo install toml-fmt`
2. `toml-fmt <Cargo.toml |sponge Cargo.toml`

Signed-off-by: Ben Werthmann <ben.werthmann@gmail.com>