### PR TITLE
Makefiles: Use dprint in child make files

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -31,10 +31,10 @@ default::
 
 # format things
 format:
-	cargo fmt
+	dprint fmt
 
 checkformat:
-	cargo fmt -- --check
+	dprint check
 
 # Clippy is the standard rule
 clippy:


### PR DESCRIPTION
Use the same dprint tooling for 'fmt-ing' that we use in top level and CI.

Signed-off-by: Ben Werthmann <ben.werthmann@gmail.com>

----

## Before

```console
$ cd ${oreboot}/src/mainboard/emulation/qemu-riscv
$ time make checkformat 
***** Oreboot Build Config *****
TOP          = /home/ben/ofw/oreboot-cicd
MODE         = release
TARGET       = riscv64imac-unknown-none-elf
TARGET_DIR   = /home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release
TOOLS_TARGET = x86_64-unknown-linux-gnu
cargo --version  = cargo 1.66.0-nightly (3cdf1ab25 2022-10-07)
rustc --version  = rustc 1.66.0-nightly (db0597f56 2022-10-11)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.66.0-nightly (db0597f56 2022-10-11)`
rustup --version = rustup 1.25.1 (bb60b1e89 2022-07-12)
**********
VENDOR       = emulation
BOARD        = qemu-riscv
cargo fmt -- --check

real	0m0.290s
user	0m0.220s
sys	0m0.071s
```
## After

```console
$ cd ${oreboot}/src/mainboard/emulation/qemu-riscv
$ time make checkformat 
***** Oreboot Build Config *****
TOP          = .../oreboot
MODE         = release
TARGET       = riscv64imac-unknown-none-elf
TARGET_DIR   = .../oreboot/target/riscv64imac-unknown-none-elf/release
TOOLS_TARGET = x86_64-unknown-linux-gnu
cargo --version  = cargo 1.66.0-nightly (3cdf1ab25 2022-10-07)
rustc --version  = rustc 1.66.0-nightly (db0597f56 2022-10-11)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.66.0-nightly (db0597f56 2022-10-11)`
rustup --version = rustup 1.25.1 (bb60b1e89 2022-07-12)
**********
VENDOR       = emulation
BOARD        = qemu-riscv
dprint check

real	0m0.199s
user	0m0.123s
sys	0m0.103s
```

## Note: `dprint` appears faster, but the bulk of the time is in `make`

```console
$ time dprint check

real	0m0.030s
user	0m0.009s
sys	0m0.049s
```