### PR TITLE
CI: Upgrade checkout actions to 'v3'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
   LintAndFormat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Install Dependencies'
         run: sudo apt-get update && make ciprepare
       - name: 'clippy linter'
@@ -34,7 +34,7 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Install Dependencies'
         run: |
           sudo apt-get update && make ciprepare
@@ -48,7 +48,7 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Install Dependencies'
         run: sudo apt-get update && make ciprepare
       - name: 'Build all mainboards'


### PR DESCRIPTION
Upgrade checkout action to 'v3' (Node.js 16).

Fix deprecation of Node.js 12 (checkout@v2) in CI Actions.

> Node.js 12 actions are deprecated. For more information see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/checkout, actions/checkout

See "Annotations" in https://github.com/oreboot/oreboot/actions/runs/3413485115

Fixes oreboot/oreboot#626

Signed-off-by: Ben Werthmann <ben.werthmann@gmail.com>