### PR TITLE
CI: Upgrade actions/codecov to 'v3'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: 'Create coverage file'
         run: make --keep-going citest
       - name: 'upload the coverage file to server'
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverall/lcov.txt
 


### PR DESCRIPTION
Upgrade actions/codecov to 'v3' (Node.js 16).

Fix deprecation of Node.js 12 (actions/codecov@v2.1.0) in CI Actions.

> Node.js 12 actions are deprecated. For more information see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: codecov/codecov-action

See "Annotations" in https://github.com/oreboot/oreboot/actions/runs/3413804136

Fixes oreboot/oreboot#626

Signed-off-by: Ben Werthmann <ben.werthmann@gmail.com>