### PR TITLE
[oreboot-soc] Upgrade d1-pac to v0.0.30

### DIFF
--- a/src/mainboard/sunxi/nezha/bt0/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/bt0/Cargo.toml
@@ -20,6 +20,10 @@ ufmt = "0.1"
 path = "../../../../soc"
 features = ["sunxi_d1"]
 
+[dependencies.riscv]
+version = "0.10.0"
+features = ["critical-section-single-hart"]
+
 [features]
 default = ["nezha"]
 

--- a/src/mainboard/sunxi/nezha/bt0/src/main.rs
+++ b/src/mainboard/sunxi/nezha/bt0/src/main.rs
@@ -19,6 +19,7 @@ use oreboot_soc::sunxi::d1::{
     time::U32Ext,
     uart::{Config, Parity, Serial, StopBits, WordLength},
 };
+use riscv as _;
 
 #[macro_use]
 mod logging;

--- a/src/mainboard/sunxi/nezha/main/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/main/Cargo.toml
@@ -11,7 +11,6 @@ buddy_system_allocator = "0.8"
 embedded-hal = "=1.0.0-alpha.8"
 lazy_static = { version = "1", features = ["spin_no_std"] }
 nb = "1"
-riscv = "0.9.0"
 # rustsbi = { path = "../rustsbi", features =["legacy"] }
 rustsbi = { version = "=0.3.0-alpha.4", features = ["legacy"] }
 sbi-spec = "0.0.2"
@@ -25,6 +24,10 @@ path = "../compression"
 [dependencies.oreboot-soc]
 path = "../../../../soc"
 features = ["sunxi_d1"]
+
+[dependencies.riscv]
+version = "0.10.0"
+features = ["critical-section-single-hart"]
 
 [features]
 default = []

--- a/src/soc/Cargo.toml
+++ b/src/soc/Cargo.toml
@@ -15,7 +15,7 @@ raw-cpuid = { version = "9.0.0", optional = true }
 util = { path = "../lib/util", optional = true }
 vcell = { version = "0.1.3", optional = true }
 
-d1-pac = { version = "0.0.23", optional = true }
+d1-pac = { version = "0.0.30", features = ["critical-section"], optional = true }
 embedded-hal = { version = "1.0.0-alpha.8", optional = true }
 nb = "1"
 


### PR DESCRIPTION
# Goal: Upgrade [d1-pac to v0.0.30](https://crates.io/crates/d1-pac/0.0.30)

* Upgrade so work in #636 is done against the most recent release of `d1-pac`. See https://github.com/duskmoon314/aw-pac/compare/d1-pac/v0.0.23...d1-pac/v0.0.30
* https://docs.rs/riscv/0.10.0/riscv/#critical-section-single-hart

## Problem1: "Peripherals::take()" method requires (https://github.com/duskmoon314/aw-pac/issues/18#issuecomment-1288497112) feature `critical-section` from d1-pac.


See CI: https://github.com/oreboot/oreboot/actions/runs/3431521920/jobs/5719748900#step:4:226

    ```
    error[E0599]: `Peripherals` is not an iterator

        --> src/mainboard/sunxi/nezha/bt0/src/main.rs:422:26
         |
    422  |     let p = Peripherals::take().unwrap();
         |                          ^^^^ `Peripherals` is not an iterator
         |
        :::
    /home/ben/.cargo/registry/src/github.com-1ecc6299db9ec823/d1-pac-0.0.30/src/lib.rs:1749:1
         |
    1749 | pub struct Peripherals {
         | ---------------------- doesn't satisfy `Peripherals: Iterator`
         |
         = note: the following trait bounds were not satisfied:
                 `Peripherals: Iterator`
                 which is required by `&mut Peripherals: Iterator`

    For more information about this error, try `rustc --explain E0599`.
    warning: `oreboot-nezha-bt0` (bin "oreboot-nezha-bt0") generated 4
    warnings
    error: could not compile `oreboot-nezha-bt0` due to previous error; 4
    warnings emitted

## Problem2: undefined symbols: `_critical_section_1_0_acquire` and `_critical_section_1_0_release`

* https://docs.rs/critical-section/latest/critical_section/#undefined-reference-errors

### oreboot_nezha_bt0

```
error: linking with `rust-lld` failed: exit status: 1
  |
  = note: "rust-lld" "-flavor" "gnu" "/tmp/rustcaqYG7Z/symbols.o" "/home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_bt0-88f7f20026ccc9f2.oreboot_nezha_bt0.8e18c697-cgu.8.rcgu.o" "--as-needed" "-L" "/home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps" "-L" "/home/ben/ofw/oreboot-cicd/target/release/deps" "-L" "/home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/build/oreboot-nezha-bt0-591e5a08a1e774ae/out" "-L" "/home/ben/.rustup/toolchains/nightly-2022-10-12-x86_64-unknown-linux-gnu/lib/rustlib/riscv64imac-unknown-none-elf/lib" "-Bstatic" "/home/ben/.rustup/toolchains/nightly-2022-10-12-x86_64-unknown-linux-gnu/lib/rustlib/riscv64imac-unknown-none-elf/lib/libcompiler_builtins-d447355f8f796940.rlib" "-Bdynamic" "-znoexecstack" "-L" "/home/ben/.rustup/toolchains/nightly-2022-10-12-x86_64-unknown-linux-gnu/lib/rustlib/riscv64imac-unknown-none-elf/lib" "-o" "/home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_bt0-88f7f20026ccc9f2" "--gc-sections" "-Tlink-nezha-bt0.ld"
  = note: rust-lld: error: undefined symbol: _critical_section_1_0_acquire
          >>> referenced by lib.rs:180 (/home/ben/.cargo/registry/src/github.com-1ecc6299db9ec823/critical-section-1.1.1/src/lib.rs:180)
          >>>               /home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_bt0-88f7f20026ccc9f2.oreboot_nezha_bt0.8e18c697-cgu.8.rcgu.o:(oreboot_nezha_bt0::main::h9917ebf46cf7a4b2)

          rust-lld: error: undefined symbol: _critical_section_1_0_release
          >>> referenced by lib.rs:1863 (/home/ben/.cargo/registry/src/github.com-1ecc6299db9ec823/d1-pac-0.0.30/src/lib.rs:1863)
          >>>               /home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_bt0-88f7f20026ccc9f2.oreboot_nezha_bt0.8e18c697-cgu.8.rcgu.o:(oreboot_nezha_bt0::main::h9917ebf46cf7a4b2)
          >>> referenced by gpio.rs:80 (src/soc/src/sunxi/d1/gpio.rs:80)
          >>>               /home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_bt0-88f7f20026ccc9f2.oreboot_nezha_bt0.8e18c697-cgu.8.rcgu.o:(oreboot_nezha_bt0::main::h9917ebf46cf7a4b2)


warning: `oreboot-nezha-bt0` (bin "oreboot-nezha-bt0") generated 10 warnings
error: could not compile `oreboot-nezha-bt0` due to previous error; 10 warnings emitted
[2022-11-09T20:26:40Z ERROR xtask::sunxi::nezha] cargo build failed with exit status: 101
make: *** [Makefile:30: mainboard] Error 1
```
### oreboot_nezha_main
```
error: linking with `rust-lld` failed: exit status: 1
  |
  = note: "rust-lld" "-flavor" "gnu" "/tmp/rustcrYk6pL/symbols.o" "/home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_main-a227eb2aa5fd6ea8.oreboot_nezha_main.a695b7ba-cgu.0.rcgu.o" "--as-needed" "-L" "/home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps" "-L" "/home/ben/ofw/oreboot-cicd/target/release/deps" "-L" "/home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/build/oreboot-nezha-main-62baa9a673ec3b27/out" "-L" "/home/ben/.rustup/toolchains/nightly-2022-10-12-x86_64-unknown-linux-gnu/lib/rustlib/riscv64imac-unknown-none-elf/lib" "-Bstatic" "/home/ben/.rustup/toolchains/nightly-2022-10-12-x86_64-unknown-linux-gnu/lib/rustlib/riscv64imac-unknown-none-elf/lib/libcompiler_builtins-d447355f8f796940.rlib" "-Bdynamic" "-znoexecstack" "-L" "/home/ben/.rustup/toolchains/nightly-2022-10-12-x86_64-unknown-linux-gnu/lib/rustlib/riscv64imac-unknown-none-elf/lib" "-o" "/home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_main-a227eb2aa5fd6ea8" "--gc-sections" "-Tlink-nezha-main.ld"
  = note: rust-lld: error: undefined symbol: _critical_section_1_0_acquire
          >>> referenced by lib.rs:180 (/home/ben/.cargo/registry/src/github.com-1ecc6299db9ec823/critical-section-1.1.1/src/lib.rs:180)
          >>>               /home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_main-a227eb2aa5fd6ea8.oreboot_nezha_main.a695b7ba-cgu.0.rcgu.o:(oreboot_nezha_main::main::h5102f4fb71f06bb6)

          rust-lld: error: undefined symbol: _critical_section_1_0_release
          >>> referenced by lib.rs:1863 (/home/ben/.cargo/registry/src/github.com-1ecc6299db9ec823/d1-pac-0.0.30/src/lib.rs:1863)
          >>>               /home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_main-a227eb2aa5fd6ea8.oreboot_nezha_main.a695b7ba-cgu.0.rcgu.o:(oreboot_nezha_main::main::h5102f4fb71f06bb6)
          >>> referenced by mod.rs:1551 (/rustc/db0597f5619d5ed93feca28e61226d3581cc7867/library/core/src/ptr/mod.rs:1551)
          >>>               /home/ben/ofw/oreboot-cicd/target/riscv64imac-unknown-none-elf/release/deps/oreboot_nezha_main-a227eb2aa5fd6ea8.oreboot_nezha_main.a695b7ba-cgu.0.rcgu.o:(oreboot_nezha_main::main::h5102f4fb71f06bb6)


warning: `oreboot-nezha-main` (bin "oreboot-nezha-main") generated 2 warnings
error: could not compile `oreboot-nezha-main` due to previous error; 2 warnings emitted
[2022-11-09T20:58:42Z ERROR xtask::sunxi::nezha] cargo build failed with exit status: 101
```

-----
# Questions

- [ ] Is there a "better" way to do address the dep on riscv than adding it to each target? I tried adding it to `oreboot-soc` as mandatory, optional, and optional with feature flags and none seem to work. 