### PR TITLE
[oreboot-soc] remove feature(int_abs_diff)

### DIFF
--- a/src/soc/src/lib.rs
+++ b/src/soc/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(int_abs_diff)]
 
 #[cfg(feature = "amd")]
 pub mod amd;


### PR DESCRIPTION
Silence the warning that `int_abs_diff` has been included since Rust 1.60.0

`oreboot-soc` does not build with a `rustc` before 1.60.0 anyway, so removing this feature is safe

Signed off by: rmsyn <rmsynchls@gmail.com>