### PR TITLE
[oreboot-nezha-bt0] remove feature(int_abs_diff)

### DIFF
--- a/src/mainboard/sunxi/nezha/bt0/src/main.rs
+++ b/src/mainboard/sunxi/nezha/bt0/src/main.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("README.md")]
 #![feature(naked_functions, asm_sym, asm_const)]
 #![feature(default_alloc_error_handler)]
-#![feature(int_abs_diff)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
Silence the warning that `int_abs_diff` has been included since Rust 1.60.0

    warning: the feature `int_abs_diff` has been stable since 1.60.0 and no longer requires an attribute to enable
     --> src/mainboard/sunxi/nezha/bt0/src/main.rs:4:12

Signed-off-by: Ben Werthmann <ben.werthmann@gmail.com>