### PR TITLE
[CI/CD] Remove `probot-auto-merge` config

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,7 +1,0 @@
----
-minApprovals:
-  COLLABORATOR: 1
-requiredLabels:
-  - automerge
-mergeMethod: rebase
-reportStatus: true


### PR DESCRIPTION
Our "merge bot" (aka `probot-auto-merge`) is a GitHub App <https://github.com/apps/probot-auto-merge> which is no longer functional, operational, or maintained.

> Hosting for this project is unmaintained as there are alternatives using GitHub Actions.

bobvanderlinden/probot-auto-merge@3da1900ecebbfc9b80e1112d4157149279f6fcaa

Closes: oreboot/oreboot#653
Signed-off-by: Ben Werthmann <ben.werthmann@gmail.com>