### PR TITLE
build Nezha with 1.66 (stable) toolchain

### DIFF
--- a/.github/workflows/toolchain-1.66.yml
+++ b/.github/workflows/toolchain-1.66.yml
@@ -1,6 +1,6 @@
 ---
 
-name: build
+name: toolchain-1.66
 
 on:  # yamllint disable-line rule:truthy
   push:

--- a/.github/workflows/toolchain-1.66.yml
+++ b/.github/workflows/toolchain-1.66.yml
@@ -1,0 +1,58 @@
+---
+
+name: build
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTUP_TOOLCHAIN: '1.66'
+
+jobs:
+  QuickFormat:
+    runs-on: ubuntu-latest
+    steps:
+      - name: git-checkout-action
+        uses: actions/checkout@v3
+      - name: dprint-check-action
+        uses: dprint/check@v2.1
+
+  LintAndFormat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Install Dependencies'
+        run: sudo apt-get update && make ciprepare
+      - name: 'clippy linter'
+        run: make --keep-going clippy
+      - name: 'Check formatting'
+        run: make --keep-going checkformat
+
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Install Dependencies'
+        run: |
+          sudo apt-get update && make ciprepare
+      - name: 'Create coverage file'
+        run: make --keep-going citest
+      - name: 'upload the coverage file to server'
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverall/lcov.txt
+
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Install Dependencies'
+        run: sudo apt-get update && make ciprepare
+      - name: 'Build all mainboards'
+        run: make --keep-going mainboards
+      - name: 'Generate report of binary sizes'
+        run: ./scripts/generate-size-report.sh

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -52,7 +52,7 @@ statically allocated size.
 The binary is generated in two steps:
 
 - Build ELF (Executable and Linkable Format) binary, with
-  `cargo build --target $(TARGET) -Z build-std=core,alloc` command.
+  `cargo build --target $(TARGET)` command.
 - Convert it to binary format with `rust-objcopy` into `bootblob.bin` file.
 
 This `bootblob.bin` is then used to construct the image that will be written

--- a/Makefile.mainboard.inc
+++ b/Makefile.mainboard.inc
@@ -27,7 +27,7 @@ $(FIXED_DTFS): fixed-dtfs.dts
 # Re-run cargo every time.
 .PHONY: $(ELF)
 $(ELF):
-	RUST_TARGET_PATH=$(TOP)/src/custom_targets cargo build --target "$(TARGET)" -Z build-std=core,alloc $(CARGO_FLAGS)
+	RUST_TARGET_PATH=$(TOP)/src/custom_targets cargo build --target "$(TARGET)" $(CARGO_FLAGS)
 
 # The default target: build the board.
 default:: mainboard

--- a/src/mainboard/emulation/qemu-riscv/.cargo/config.toml
+++ b/src/mainboard/emulation/qemu-riscv/.cargo/config.toml
@@ -5,6 +5,4 @@ target = "riscv64imac-unknown-none-elf"
 rustflags = [
   "-C",
   "link-arg=-Tlink.ld",
-  "-Z",
-  "emit-stack-sizes",
 ]

--- a/src/mainboard/sunxi/nezha/main/.cargo/config.toml
+++ b/src/mainboard/sunxi/nezha/main/.cargo/config.toml
@@ -5,6 +5,4 @@ target = "riscv64imac-unknown-none-elf"
 rustflags = [
   "-C",
   "link-arg=-Tlink-nezha-main.ld",
-  "-Z",
-  "emit-stack-sizes",
 ]

--- a/src/soc/Cargo.toml
+++ b/src/soc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 consts = { path = "../lib/consts" }
 oreboot-arch = { path = "../arch", optional = true }
 oreboot-cpu = { path = "../cpu", optional = true }
-tock-registers = "0.7.0"
+tock-registers = "0.8.1"
 
 heapless = { version = "0.6.1", optional = true }
 raw-cpuid = { version = "9.0.0", optional = true }


### PR DESCRIPTION
Experimental. This is as far as I made it with `make RUSTUP_TOOLCHAIN=1.66`.

Relates to #551