### PR TITLE
Update Rust toolchain to nightly-2022-12-15

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-12-13"
+channel = "nightly-2022-12-15"
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]
 targets = [
   "aarch64-unknown-none-softfloat",


### PR DESCRIPTION
Signed-off-by: Ben Werthmann <ben.werthmann@gmail.com>