### PR TITLE
lib/log: rework without global allocator

### DIFF
--- a/src/lib/log/src/lib.rs
+++ b/src/lib/log/src/lib.rs
@@ -1,32 +1,52 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
-//! This is a simple logger for oreboot, built on top of Rust embedded_hal.
+//! This is a simple logger for oreboot, built on top of Rust `embedded_hal`.
+//!
 //! We expose the two macros `print!` and `println!` as well as the direct
-//! `_print` and `_debug` methods. The former is not inteded for use, while
-//! `_debug` serves as a fallback in case platform bringup gets really hard.
+//! `print` and `debug` methods. The former is not inteded for direct use, while
+//! `debug` serves as a fallback in case platform bringup gets really hard.
+//!
 //! Implement the embedded_hal non-blocking (nb) serial write trait, initialize
-//! your serial, and pass it along via `set_logger` to use the macros.
+//! your serial, and pass it along via `log::init` to use the macros.
+//!
+//! You will need to create a `&'static mut`, which you can achieve  by wrapping
+//! your serial in a `static mut` holding an `Option` for your serial's type and
+//! extracting it again in `.as_mut().unwrap()`. Consider putting that into a
+//! function and adding either a `spin::Once` or some other gating mechanism to
+//! avoid dupliate initialization and mutable aliasing.
+//! It may simply `panic!()` if you choose so.
+//!
+//! Here is an example for a `spin::Once` that results in a no-op for further
+//! calls to `init_logger()`, being tolerant at runtime:
 //!
 //! ```rs
-//!     // MySerial implements embedded_hal::serial::nb::Write
+//! // MySerial implements embedded_hal::serial::nb::Write
+//! fn init_logger(s: MySerial) {
+//!     static ONCE: spin::Once<()> = spin::Once::new();
+//!
+//!     ONCE.call_once(|| unsafe {
+//!         static mut SERIAL: Option<MySerial> = None;
+//!         SERIAL.replace(s);
+//!         log::init(SERIAL.as_mut().unwrap());
+//!     });
+//! }
+//!
+//! fn main() {
+//!     /* ... */
 //!     let serial = init::MySerial::new(some_peripheral);
-//!     log::set_logger(serial);
-//!     log::_debug(42);
+//!     init_logger(serial);
+//!     log::debug(42);
 //!     println!("oreboot 🦀");
+//!     /* ... */
+//! }
 //! ```
 #![no_std]
 
-extern crate alloc;
-use alloc::boxed::Box;
-use core::{
-    alloc::{GlobalAlloc, Layout},
-    fmt,
-    ptr::null_mut,
-};
+use core::fmt;
 use embedded_hal::serial::{nb::Write, ErrorType};
 use nb::block;
-use spin::{Mutex, Once};
+use spin::Mutex;
 
-pub trait Serial: ErrorType + Write {
+pub trait Serial: ErrorType + Write + Send {
     /// This is meant to be the simplest fallback for debugging:
     /// A "sign of life", possibly an LED flashing (GPIO high/low...),
     /// an unforgiving write to a UART without polling for status or anything,
@@ -35,18 +55,14 @@ pub trait Serial: ErrorType + Write {
 }
 
 /// Set the globally available logger that enables the macros.
-pub fn set_logger<S: Serial<Error = Error> + 'static>(serial: S) {
-    unsafe {
-        LOGGER.0.call_once(|| LockedLogger {
-            l: Mutex::new(Box::new(serial)),
-        });
-    }
+pub fn init(serial: &'static mut SerialLogger) {
+    LOGGER.lock().replace(serial);
 }
 
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {
-        $crate::_print(core::format_args!($($arg)*));
+        $crate::print(core::format_args!($($arg)*));
     }
 }
 
@@ -54,7 +70,7 @@ macro_rules! print {
 macro_rules! println {
     () => ($crate::print!("\n"));
     ($($arg:tt)*) => {
-        $crate::_print(core::format_args!($($arg)*));
+        $crate::print(core::format_args!($($arg)*));
         $crate::print!("\n");
     }
 }
@@ -66,7 +82,6 @@ pub struct Error {
 }
 
 impl embedded_hal::serial::Error for Error {
-    #[inline]
     fn kind(&self) -> embedded_hal::serial::ErrorKind {
         self.kind
     }
@@ -74,35 +89,16 @@ impl embedded_hal::serial::Error for Error {
 
 type SerialLogger = dyn Serial<Error = Error>;
 
-#[doc(hidden)]
-struct LockedLogger {
-    l: Mutex<Box<SerialLogger>>,
-}
-
-// We wrap this to fulfill the orphan rule. See the Rust book for more details:
-// https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#using-the-newtype-pattern-to-implement-external-traits-on-external-types
-struct Wrap<T>(T);
-type Logger = Wrap<Once<LockedLogger>>;
-
-unsafe impl GlobalAlloc for Logger {
-    unsafe fn alloc(&self, _layout: Layout) -> *mut u8 {
-        null_mut()
-    }
-    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
-}
-
-#[doc(hidden)]
-#[global_allocator]
-static mut LOGGER: Logger = Wrap(Once::new());
+static LOGGER: Mutex<Option<&'static mut SerialLogger>> = Mutex::new(None);
 
 impl fmt::Write for SerialLogger {
-    #[inline]
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
-        for byte in s.as_bytes() {
+        for &byte in s.as_bytes() {
+            // Inject a carriage return before a newline
             if byte == b'\n' {
                 block!(self.write(b'\r')).unwrap();
             }
-            block!(self.write(*byte)).unwrap();
+            block!(self.write(byte)).unwrap();
         }
         block!(self.flush()).unwrap();
         Ok(())
@@ -110,15 +106,11 @@ impl fmt::Write for SerialLogger {
 }
 
 #[doc(hidden)]
-pub fn _print(args: fmt::Arguments) {
+pub fn print(args: fmt::Arguments) {
     use fmt::Write;
-    unsafe {
-        LOGGER.0.wait().l.lock().write_fmt(args).unwrap();
-    }
+    LOGGER.lock().as_mut().unwrap().write_fmt(args).unwrap();
 }
 
-pub fn _debug(num: u8) {
-    unsafe {
-        LOGGER.0.wait().l.lock().debug(num);
-    }
+pub fn debug(num: u8) {
+    LOGGER.lock().as_mut().unwrap().debug(num);
 }


### PR DESCRIPTION
Huge kudos to @dancrossnyc for walking through this with us.

Less code, more safety, no global alloc - this turned out to be much nicer :)