### PR TITLE
lib/log: mutex and debug features, drop debug fn

### DIFF
--- a/src/lib/log/Cargo.toml
+++ b/src/lib/log/Cargo.toml
@@ -5,6 +5,12 @@ authors = ["oreboot Authors"]
 edition = "2021"
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.8"
+embedded-hal = "=1.0.0-alpha.9"
+embedded-hal-nb = "=1.0.0-alpha.1"
 nb = "1"
 spin = "0.9"
+
+[features]
+default = []
+debug = []
+mutex = []


### PR DESCRIPTION
Dan Cross is right; the debug function does not need to come from here.
If one wanted, one could optionally add that to a specific
implementation.

Instead, add some handy functions for debugging here, to print values as
hex, pointers, etc.. They will help you e.g. when the memory map is
unclear and the print! macro would want to use absolute instead of
relative memory addresses. It helped me figure out the JH7110 SoC.

And because some platforms may not allow for using atomics in SRAM, make
the mutex in this crate opt-in.

Signed-off-by: Daniel Maslowski <info@orangecms.org>
