### PR TITLE
visionfive2 main.rs: use let Some(), not unwrap

### DIFF
--- a/src/mainboard/starfive/visionfive2/bt0/src/main.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/main.rs
@@ -208,8 +208,9 @@ static mut SERIAL: Option<JH71XXSerial> = None;
 fn init_logger(s: JH71XXSerial) {
     unsafe {
         SERIAL.replace(s);
-        let m = SERIAL.as_mut().unwrap();
-        log::init(m);
+        if let Some(m) = SERIAL.as_mut() {
+            log::init(m);
+        }
     }
 }
 


### PR DESCRIPTION
Unwrap can be very dangerous in firmare; as code
evolves, we have found it can explode in unexpected ways.

Use let some instead.