### PR TITLE
Add .gdb_history file to list of git ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Cargo.lock
 
 # Ignore all intellij related files
 *.idea
+
+# gdb history files
+.gdb_history


### PR DESCRIPTION
Those files are created at random places in the repo every time I try to debug something using gdb + gef
Signed-off-by: Ahmed <ahmedsoliman@oddcoder.com>