### PR TITLE
[qemu-riscv] Build fix

### DIFF
--- a/src/mainboard/emulation/qemu-riscv/link.ld
+++ b/src/mainboard/emulation/qemu-riscv/link.ld
@@ -26,7 +26,7 @@ ENTRY(_boot);
 
 SECTIONS
 {
-    . = 0x20000000;
+    . = 0x80000000;
     .bootblock :
     {
         KEEP(*(.bootblock.boot));

--- a/src/mainboard/emulation/qemu-riscv/link.ld
+++ b/src/mainboard/emulation/qemu-riscv/link.ld
@@ -31,21 +31,36 @@ SECTIONS
     {
         KEEP(*(.bootblock.boot));
     }
-    .text :
-    {
-        KEEP(*(.text .text.*));
+    .text : {
+        KEEP(*(.text.entry))
+        *(.text .text.*)
     }
-    .rodata :
-    {
-        KEEP(*(.rodata .rodata.*));
+    .rodata : ALIGN(4) {
+        srodata = .;
+        *(.rodata .rodata.*)
+        *(.srodata .srodata.*)
+        . = ALIGN(4);
+        erodata = .;
     }
-
-    .stack_sizes (INFO) :
-    {
+    .data : ALIGN(4) {
+        sdata = .;
+        *(.data .data.*)
+        *(.sdata .sdata.*)
+        . = ALIGN(4);
+        edata = .;
+    }
+    sidata = LOADADDR(.data);
+    .bss (NOLOAD) : ALIGN(4) {
+        *(.bss.uninit)
+        sbss = .;
+        *(.bss .bss.*)
+        *(.sbss .sbss.*)
+        ebss = .;
+    }
+    .stack_sizes (INFO) : {
         KEEP(*(.stack_sizes));
     }
-
-    /DISCARD/ : { *(.comment) *(.gnu*) *(.note*) *(.eh_frame*)
-    /* Unused exception related info that only wastes space */
+    /DISCARD/ : {
+        *(.eh_frame)
     }
 }

--- a/src/mainboard/emulation/qemu-riscv/src/main.rs
+++ b/src/mainboard/emulation/qemu-riscv/src/main.rs
@@ -3,8 +3,11 @@
 #![no_std]
 #![no_main]
 
+use core::arch::global_asm;
 use core::panic::PanicInfo;
 use ns16550a::*;
+global_asm!(include_str!("bootblock.S"));
+global_asm!(include_str!("init.S"));
 
 const SERIAL_PORT_BASE_ADDRESS: usize = 0x1000_0000;
 


### PR DESCRIPTION
This patch set fixes a collection of bugs in the build process of qemu-riscv target. Even thought the qemu-riscv target builds and to some extent works, that souldn't have done, and the only reason it worked previously is sheer luck. The initial boot starter assembly blob was never used. In addition to that, The load address for the binary was not correct and some unnecessary symbols were forced to be kept which gave some linker error once we start doing anything remotely interesting in the rom.