### PR TITLE
upgrade tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,9 @@ help:
 # Turn them all off. We'll turn them back on to try to get to working tests.
 MAINBOARDS := $(wildcard src/mainboard/*/*/Makefile)
 
-BINUTILS_VER := 0.3.4
-STACK_SIZES_VER := 0.4.0
+BINUTILS_VER := 0.3.6
 TARPAULIN_VER := 0.19.1
-DPRINT_VER := 0.36.1
+DPRINT_VER := 0.40.2
 
 CARGOINST := rustup run --install 1.67 cargo install
 
@@ -32,13 +31,11 @@ $(MAINBOARDS):
 
 firsttime:
 	$(CARGOINST) $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
-	$(CARGOINST) $(if $(STACK_SIZES_VER),--version $(STACK_SIZES_VER),) stack-sizes
 	$(CARGOINST) $(if $(TARPAULIN_VER),--version $(TARPAULIN_VER),) cargo-tarpaulin
 	$(CARGOINST) $(if $(DPRINT_VER),--version $(DPRINT_VER),) dprint
 
 nexttime:
 	$(CARGOINST) --force $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
-	$(CARGOINST) --force $(if $(STACK_SIZES_VER),--version $(STACK_SIZES_VER),) stack-sizes
 	$(CARGOINST) --force $(if $(TARPAULIN_VER),--version $(TARPAULIN_VER),) cargo-tarpaulin
 	$(CARGOINST) --force $(if $(DPRINT_VER),--version $(DPRINT_VER),) dprint
 

--- a/dprint.json
+++ b/dprint.json
@@ -1,9 +1,13 @@
 {
+  "exec": {
+    "commands": [{
+      "command": "rustfmt --edition 2021",
+      "exts": ["rs"]
+    }]
+  },
   "json": {
   },
   "markdown": {
-  },
-  "rustfmt": {
   },
   "toml": {
   },
@@ -14,9 +18,9 @@
     "3rdparty/"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/rustfmt-0.6.2.json@886c6f3161cf020c2d75160262b0f56d74a521e05cfb91ec4f956650c8ca76ca",
-    "https://plugins.dprint.dev/json-0.16.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.14.1.wasm",
+    "https://plugins.dprint.dev/exec-0.4.3.json@42343548b8022c99b1d750be6b894fe6b6c7ee25f72ae9f9082226dd2e515072",
+    "https://plugins.dprint.dev/json-0.17.1.wasm",
+    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm"
   ]
 }


### PR DESCRIPTION
- dprint needs an upgrade: https://github.com/dprint/dprint/issues/731
- remove stack-sizes; it is a library and cannot be installed as a binary