### PR TITLE
feature: VisionFive2 PAC for peripheral access

### DIFF
--- a/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
+++ b/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
@@ -18,7 +18,6 @@ layoutflash = { path = "../../../../lib/layoutflash" }
 log = { path = "../../../../lib/log" }
 
 [dependencies.jh71xx-pac]
-git = "https://github.com/rmsyn/jh71xx-pac"
 version = "0.2"
 
 [features]

--- a/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
+++ b/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
@@ -16,3 +16,12 @@ spin = "0.9"
 
 layoutflash = { path = "../../../../lib/layoutflash" }
 log = { path = "../../../../lib/log" }
+
+[dependencies.jh71xx-pac]
+git = "https://github.com/rmsyn/jh71xx-pac"
+version = "0.2"
+
+[features]
+default = ["12a"]
+12a = ["jh71xx-pac/visionfive2-12a"]
+13b = ["jh71xx-pac/visionfive2-13b"]

--- a/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
+++ b/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
@@ -18,9 +18,4 @@ layoutflash = { path = "../../../../lib/layoutflash" }
 log = { path = "../../../../lib/log" }
 
 [dependencies.jh71xx-pac]
-version = "0.2"
-
-[features]
-default = ["12a"]
-12a = ["jh71xx-pac/visionfive2-12a"]
-13b = ["jh71xx-pac/visionfive2-13b"]
+version = "0.3"

--- a/src/mainboard/starfive/visionfive2/bt0/src/dram.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/dram.rs
@@ -2,7 +2,7 @@ use crate::ddr_start::start;
 use crate::ddrcsr::omc_init;
 use crate::ddrphy::{train, util};
 use crate::init::{self, read32, udelay, write32};
-use crate::pll;
+use crate::{pac, pll};
 
 // see StarFive U-Boot drivers/ram/starfive/starfive_ddr.c
 pub fn init() {
@@ -35,31 +35,75 @@ pub fn init() {
         udelay(200);
 
         println!("[DRAM] asserts");
+        let syscrg = pac::syscrg_reg();
+
         // DDR OSC
-        init::set_bit(init::SYS_CRG_RESET_ASSERT1, init::RSTN_U0_DDR_OSC);
-        while (read32(init::SYS_CRG_RESET_STATUS1) >> init::RSTN_U0_DDR_OSC) & 1 == 1 {
+        syscrg
+            .soft_rst_addr_sel_1()
+            .modify(|_, w| w.u0_ddr_osc().set_bit());
+        while syscrg
+            .syscrg_rst_status_1()
+            .read()
+            .u0_ddr_osc()
+            .bit_is_set()
+        {
             udelay(1);
         }
-        init::clear_bit(init::SYS_CRG_RESET_ASSERT1, init::RSTN_U0_DDR_OSC);
-        while (read32(init::SYS_CRG_RESET_STATUS1) >> init::RSTN_U0_DDR_OSC) & 1 == 0 {
+        syscrg
+            .soft_rst_addr_sel_1()
+            .modify(|_, w| w.u0_ddr_osc().clear_bit());
+        while syscrg
+            .syscrg_rst_status_1()
+            .read()
+            .u0_ddr_osc()
+            .bit_is_clear()
+        {
             udelay(1);
         }
         // DDR APB
-        init::set_bit(init::SYS_CRG_RESET_ASSERT1, init::RSTN_U0_DDR_APB);
-        while (read32(init::SYS_CRG_RESET_STATUS1) >> init::RSTN_U0_DDR_APB) & 1 == 1 {
+        syscrg
+            .soft_rst_addr_sel_1()
+            .modify(|_, w| w.u0_ddr_apb().set_bit());
+        while syscrg
+            .syscrg_rst_status_1()
+            .read()
+            .u0_ddr_apb()
+            .bit_is_set()
+        {
             udelay(1);
         }
-        init::clear_bit(init::SYS_CRG_RESET_ASSERT1, init::RSTN_U0_DDR_APB);
-        while (read32(init::SYS_CRG_RESET_STATUS1) >> init::RSTN_U0_DDR_APB) & 1 == 0 {
+        syscrg
+            .soft_rst_addr_sel_1()
+            .modify(|_, w| w.u0_ddr_apb().clear_bit());
+        while syscrg
+            .syscrg_rst_status_1()
+            .read()
+            .u0_ddr_apb()
+            .bit_is_clear()
+        {
             udelay(1);
         }
         // DDR AXI
-        init::set_bit(init::SYS_CRG_RESET_ASSERT1, init::RSTN_U0_DDR_AXI);
-        while (read32(init::SYS_CRG_RESET_STATUS1) >> init::RSTN_U0_DDR_AXI) & 1 == 1 {
+        syscrg
+            .soft_rst_addr_sel_1()
+            .modify(|_, w| w.u0_ddr_axi().set_bit());
+        while syscrg
+            .syscrg_rst_status_1()
+            .read()
+            .u0_ddr_axi()
+            .bit_is_set()
+        {
             udelay(1);
         }
-        init::clear_bit(init::SYS_CRG_RESET_ASSERT1, init::RSTN_U0_DDR_AXI);
-        while (read32(init::SYS_CRG_RESET_STATUS1) >> init::RSTN_U0_DDR_AXI) & 1 == 0 {
+        syscrg
+            .soft_rst_addr_sel_1()
+            .modify(|_, w| w.u0_ddr_axi().clear_bit());
+        while syscrg
+            .syscrg_rst_status_1()
+            .read()
+            .u0_ddr_axi()
+            .bit_is_clear()
+        {
             udelay(1);
         }
 

--- a/src/mainboard/starfive/visionfive2/bt0/src/init.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/init.rs
@@ -178,10 +178,12 @@ pub fn clk_apb0() {
 }
 
 pub fn clk_ddrc_axi(on: bool) {
-    let v = if on { DDR_AXI_ON } else { DDR_AXI_OFF };
-    let ddr_axi = read32(CLK_U0_DDR_AXI);
-    println!("ddr_axi {ddr_axi:x}");
-    write32(CLK_U0_DDR_AXI, ddr_axi & !(1 << 31) | v);
+    syscrg_reg().clk_u0_ddr_axi().modify(|r, w| {
+        let ddr_axi = r.bits();
+        println!("ddr_axi {ddr_axi:x}");
+
+        w.clk_icg().variant(on)
+    });
 }
 
 pub fn clk_ddrc_osc_div2() {

--- a/src/mainboard/starfive/visionfive2/bt0/src/init.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/init.rs
@@ -109,10 +109,10 @@ const CLK_ICG_ON: u32 = 1 << 31;
 // 24-29 clk_mux_sel
 const DDR_BUS_MASK: u32 = !(0x3f00_0000);
 
-const DDR_BUS_OSC_DIV2: u32 = 0 << 24;
-const DDR_BUS_PLL1_DIV2: u32 = 1 << 24;
-const DDR_BUS_PLL1_DIV4: u32 = 2 << 24;
-const DDR_BUS_PLL1_DIV8: u32 = 3 << 24;
+const DDR_BUS_OSC_DIV2: u8 = 0;
+const DDR_BUS_PLL1_DIV2: u8 = 1;
+const DDR_BUS_PLL1_DIV4: u8 = 2;
+const DDR_BUS_PLL1_DIV8: u8 = 3;
 
 const CLK_QSPI_REF: usize = SYS_CRG_BASE + 0x0168;
 const CLK_QSPI_REF_MUX_SEL: u8 = 1; // QSPI ref src
@@ -187,23 +187,19 @@ pub fn clk_ddrc_axi(on: bool) {
 }
 
 pub fn clk_ddrc_osc_div2() {
-    let ddr_bus = read32(CLK_U0_DDR_BUS) & DDR_BUS_MASK;
-    write32(CLK_U0_DDR_BUS, ddr_bus | DDR_BUS_OSC_DIV2);
+    syscrg_reg().clk_ddr_bus().modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_OSC_DIV2));
 }
 
 pub fn clk_ddrc_pll1_div2() {
-    let ddr_bus = read32(CLK_U0_DDR_BUS) & DDR_BUS_MASK;
-    write32(CLK_U0_DDR_BUS, ddr_bus | DDR_BUS_PLL1_DIV2);
+    syscrg_reg().clk_ddr_bus().modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV2));
 }
 
 pub fn clk_ddrc_pll1_div4() {
-    let ddr_bus = read32(CLK_U0_DDR_BUS) & DDR_BUS_MASK;
-    write32(CLK_U0_DDR_BUS, ddr_bus | DDR_BUS_PLL1_DIV4);
+    syscrg_reg().clk_ddr_bus().modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV4));
 }
 
 pub fn clk_ddrc_pll1_div8() {
-    let ddr_bus = read32(CLK_U0_DDR_BUS) & DDR_BUS_MASK;
-    write32(CLK_U0_DDR_BUS, ddr_bus | DDR_BUS_PLL1_DIV8);
+    syscrg_reg().clk_ddr_bus().modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV8));
 }
 
 pub const SYS_AON_BASE: usize = 0x1700_0000;

--- a/src/mainboard/starfive/visionfive2/bt0/src/init.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/init.rs
@@ -69,10 +69,8 @@ pub const SYS_CRG_BASE: usize = 0x1302_0000;
 pub const CLK_CPU_ROOT: usize = SYS_CRG_BASE;
 pub const CLK_CPU_ROOT_SW: u8 = 1; // PLL0 (?)
 
-const CLK_PERH_ROOT: usize = SYS_CRG_BASE + 0x0010;
 const CLK_PERH_ROOT_MUX_SEL: u8 = 1; // pll2
 
-pub const CLK_BUS_ROOT: usize = SYS_CRG_BASE + 0x0014;
 pub const CLK_BUS_ROOT_SW: u8 = 1; // PLL2 (?)
 
 pub const CLK_AHB0: usize = SYS_CRG_BASE + 0x0024;
@@ -115,9 +113,6 @@ const CLK_QSPI_REF: usize = SYS_CRG_BASE + 0x0168;
 const CLK_QSPI_REF_MUX_SEL: u8 = 1; // QSPI ref src
 const CLK_NOC_BUS_STG_AXI: usize = SYS_CRG_BASE + 0x0180;
 const CLK_NOC_BUS_STG_AXI_CLK_ICG_EN: u32 = 1 << 31;
-
-const CLK_AON_APB_FUNC: usize = SYS_AON_BASE + 0x0004;
-const CLK_AON_APB_FUNC_MUX_SEL: u8 = 1; // OSC
 
 pub fn clk_cpu_root() {
     // Select clk_pll0 as the CPU root clock
@@ -186,131 +181,3 @@ pub fn clk_ddrc_pll1_div4() {
 pub fn clk_ddrc_pll1_div8() {
     pac::syscrg_reg().clk_ddr_bus().modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV8));
 }
-
-pub const SYS_AON_BASE: usize = 0x1700_0000;
-
-/* SYS SYSCON */
-pub const SYS_SYSCON_BASE: usize = 0x1303_0000;
-
-pub const SYS_SYSCON_00: usize = SYS_SYSCON_BASE;
-pub const SYS_SYSCON_04: usize = SYS_SYSCON_BASE + 0x0004;
-pub const SYS_SYSCON_08: usize = SYS_SYSCON_BASE + 0x0008;
-pub const SYS_SYSCON_12: usize = SYS_SYSCON_BASE + 0x000c;
-pub const SYS_SYSCON_16: usize = SYS_SYSCON_BASE + 0x0010;
-pub const SYS_SYSCON_20: usize = SYS_SYSCON_BASE + 0x0014;
-pub const SYS_SYSCON_24: usize = SYS_SYSCON_BASE + 0x0018;
-pub const SYS_SYSCON_28: usize = SYS_SYSCON_BASE + 0x001c;
-pub const SYS_SYSCON_32: usize = SYS_SYSCON_BASE + 0x0020;
-pub const SYS_SYSCON_36: usize = SYS_SYSCON_BASE + 0x0024;
-pub const SYS_SYSCON_40: usize = SYS_SYSCON_BASE + 0x0028;
-pub const SYS_SYSCON_44: usize = SYS_SYSCON_BASE + 0x002c;
-pub const SYS_SYSCON_48: usize = SYS_SYSCON_BASE + 0x0030;
-pub const SYS_SYSCON_52: usize = SYS_SYSCON_BASE + 0x0034;
-
-/* GPIO mux */
-
-pub const SYS_IOMUX_BASE: usize = 0x1304_0000;
-
-// NOTE: 4 GPIOs per DWORD
-/*
-const GPIO00_03_EN: usize = SYS_IOMUX_BASE;
-*/
-pub const GPIO04_07_EN: usize = SYS_IOMUX_BASE + 0x0004;
-/*
-const GPIO08_11_EN: usize = SYS_IOMUX_BASE + 0x0008;
-const GPIO12_15_EN: usize = SYS_IOMUX_BASE + 0x000c;
-const GPIO16_19_EN: usize = SYS_IOMUX_BASE + 0x0010;
-const GPIO20_23_EN: usize = SYS_IOMUX_BASE + 0x0014;
-const GPIO24_27_EN: usize = SYS_IOMUX_BASE + 0x0018;
-const GPIO28_31_EN: usize = SYS_IOMUX_BASE + 0x001c;
-const GPIO32_35_EN: usize = SYS_IOMUX_BASE + 0x0020;
-const GPIO36_39_EN: usize = SYS_IOMUX_BASE + 0x0024;
-*/
-pub const GPIO40_43_EN: usize = SYS_IOMUX_BASE + 0x0028;
-/*
-const GPIO44_47_EN: usize = SYS_IOMUX_BASE + 0x002c;
-const GPIO48_51_EN: usize = SYS_IOMUX_BASE + 0x0030;
-const GPIO52_55_EN: usize = SYS_IOMUX_BASE + 0x0034;
-const GPIO56_59_EN: usize = SYS_IOMUX_BASE + 0x0038;
-const GPIO60_63_EN: usize = SYS_IOMUX_BASE + 0x003c;
-
-const GPIO00_03_DATA: usize = SYS_IOMUX_BASE + 0x0040;
-const GPIO04_07_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0004;
-const GPIO08_11_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0008;
-const GPIO12_15_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x000c;
-const GPIO16_19_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0010;
-const GPIO20_23_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0014;
-const GPIO24_27_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0018;
-const GPIO28_31_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x001c;
-const GPIO32_35_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0020;
-const GPIO36_39_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0024;
-*/
-pub const GPIO40_43_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0028;
-/*
-const GPIO44_47_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x002c;
-const GPIO48_51_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0030;
-const GPIO52_55_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0034;
-const GPIO56_59_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x0038;
-const GPIO60_63_DATA: usize = SYS_IOMUX_BASE + 0x0040 + 0x003c;
-*/
-
-// NOTE: we may not need this; copied from StarFive / U-Boot
-// This is the base address for input data, AIUI from the manual.
-// const SYS_IOMUX_32: usize = SYS_IOMUX_BASE + 0x0080;
-
-pub const GPIO_DOEN_MASK: u8 = 0x3f;
-pub const GPIO_DOUT_MASK: u8 = 0x7f;
-
-/*
- * const GPIO_OUT_FUNC_OFF: u8 = 0x00;
- * const GPIO_OUT_FUNC_ON: u8 = 0x01;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x02;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x03;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x04;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x05;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x06;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x07;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x08;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x09;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x0a;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x0b;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x0c;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x0d;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x0e;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x0f;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x10;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x11;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x12;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x13;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x14;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x15;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x16;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x17;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x18;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x19;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x1a;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x1b;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x1c;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x1d;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x1e;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x1f;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x20;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x21;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x22;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x23;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x24;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x25;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x26;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x27;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x28;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x29;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x2a;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x2b;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x2c;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x2d;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x2e;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x2f;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x30;
- * const GPIO_OUT_FUNC_XXX: u8 = 0x31;
- * NOTE: GPIO OUT has 49 functions
- */

--- a/src/mainboard/starfive/visionfive2/bt0/src/init.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/init.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "12a")]
-use jh71xx_pac::jh7110_vf2_12a_pac as pac;
+pub(crate) use jh71xx_pac::jh7110_vf2_12a_pac as pac;
 #[cfg(feature = "13b")]
-use jh71xx_pac::jh7110_vf2_13b_pac as pac;
+pub(crate) use jh71xx_pac::jh7110_vf2_13b_pac as pac;
 
 use core::arch::asm;
 use core::ptr::{read_volatile, write_volatile};

--- a/src/mainboard/starfive/visionfive2/bt0/src/init.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/init.rs
@@ -116,29 +116,40 @@ const CLK_NOC_BUS_STG_AXI_CLK_ICG_EN: u32 = 1 << 31;
 
 pub fn clk_cpu_root() {
     // Select clk_pll0 as the CPU root clock
-    pac::syscrg_reg().clk_cpu_root().modify(|_, w| w.clk_mux_sel().variant(CLK_CPU_ROOT_SW));
+    pac::syscrg_reg()
+        .clk_cpu_root()
+        .modify(|_, w| w.clk_mux_sel().variant(CLK_CPU_ROOT_SW));
 }
 
 pub fn clk_bus_root() {
     // Select clk_pll2 as the BUS root clock
-    pac::syscrg_reg().clk_bus_root().modify(|_, w| w.clk_mux_sel().variant(CLK_BUS_ROOT_SW));
+    pac::syscrg_reg()
+        .clk_bus_root()
+        .modify(|_, w| w.clk_mux_sel().variant(CLK_BUS_ROOT_SW));
 }
 
 pub fn clocks() {
     let syscrg = pac::syscrg_reg();
 
     // Set clk_pll2 as the peripheral root clock
-    syscrg.clk_peripheral_root()
+    syscrg
+        .clk_peripheral_root()
         .modify(|_, w| w.clk_mux_sel().variant(CLK_PERH_ROOT_MUX_SEL));
 
     // Enable the NOC STG clock
-    syscrg.clk_noc_stg_axi().modify(|_, w| w.clk_icg().set_bit());
+    syscrg
+        .clk_noc_stg_axi()
+        .modify(|_, w| w.clk_icg().set_bit());
 
     // Set clk_osc_div4 as the APB clock
-    pac::aoncrg_reg().clk_aon_apb().modify(|_, w| w.clk_mux_sel().variant(0));
+    pac::aoncrg_reg()
+        .clk_aon_apb()
+        .modify(|_, w| w.clk_mux_sel().variant(0));
 
     // Set clk_qspi_ref_src as the QSPI clock
-    syscrg.clk_qspi_ref().modify(|_, w| w.clk_mux_sel().variant(CLK_QSPI_REF_MUX_SEL));
+    syscrg
+        .clk_qspi_ref()
+        .modify(|_, w| w.clk_mux_sel().variant(CLK_QSPI_REF_MUX_SEL));
 }
 
 pub fn clk_apb0() {
@@ -167,17 +178,25 @@ pub fn clk_ddrc_axi(on: bool) {
 }
 
 pub fn clk_ddrc_osc_div2() {
-    pac::syscrg_reg().clk_ddr_bus().modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_OSC_DIV2));
+    pac::syscrg_reg()
+        .clk_ddr_bus()
+        .modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_OSC_DIV2));
 }
 
 pub fn clk_ddrc_pll1_div2() {
-    pac::syscrg_reg().clk_ddr_bus().modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV2));
+    pac::syscrg_reg()
+        .clk_ddr_bus()
+        .modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV2));
 }
 
 pub fn clk_ddrc_pll1_div4() {
-    pac::syscrg_reg().clk_ddr_bus().modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV4));
+    pac::syscrg_reg()
+        .clk_ddr_bus()
+        .modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV4));
 }
 
 pub fn clk_ddrc_pll1_div8() {
-    pac::syscrg_reg().clk_ddr_bus().modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV8));
+    pac::syscrg_reg()
+        .clk_ddr_bus()
+        .modify(|_, w| w.clk_mux_sel().variant(DDR_BUS_PLL1_DIV8));
 }

--- a/src/mainboard/starfive/visionfive2/bt0/src/init.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/init.rs
@@ -162,12 +162,19 @@ pub fn clocks() {
 }
 
 pub fn clk_apb0() {
-    let clk = read32(CLK_APB0);
-    println!("apb0 {clk:x}");
-    write32(CLK_APB0, 0); // try a reset
-    write32(CLK_APB0, clk | CLK_ICG_ON);
-    let clk = read32(CLK_APB0);
-    println!("apb0 {clk:x}");
+    syscrg_reg().clk_apb0().modify(|r, w| {
+        let clk = r.bits();
+        println!("apb0 {clk:x}");
+
+        // try a reset
+        w.clk_icg().clear_bit();
+        w.clk_icg().set_bit();
+
+        let clk = r.bits();
+        println!("apb0 {clk:x}");
+
+        w
+    });
 }
 
 pub fn clk_ddrc_axi(on: bool) {

--- a/src/mainboard/starfive/visionfive2/bt0/src/init.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/init.rs
@@ -76,7 +76,7 @@ const CLK_PERH_ROOT: usize = SYS_CRG_BASE + 0x0010;
 const CLK_PERH_ROOT_MUX_SEL: u32 = 1 << 24; // pll2
 
 pub const CLK_BUS_ROOT: usize = SYS_CRG_BASE + 0x0014;
-pub const CLK_BUS_ROOT_SW: u32 = 1 << 24; // PLL2 (?)
+pub const CLK_BUS_ROOT_SW: u8 = 1; // PLL2 (?)
 
 pub const CLK_AHB0: usize = SYS_CRG_BASE + 0x0024;
 pub const CLK_APB0: usize = SYS_CRG_BASE + 0x0030;
@@ -134,8 +134,8 @@ pub fn clk_cpu_root() {
 }
 
 pub fn clk_bus_root() {
-    let v = read32(CLK_BUS_ROOT) & !(0xcf00_0000);
-    write32(CLK_BUS_ROOT, v | CLK_BUS_ROOT_SW);
+    // Select clk_pll2 as the BUS root clock
+    syscrg_reg().clk_bus_root().modify(|_, w| w.clk_mux_sel().variant(CLK_BUS_ROOT_SW));
 }
 
 pub fn clocks() {

--- a/src/mainboard/starfive/visionfive2/bt0/src/main.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/main.rs
@@ -39,13 +39,6 @@ const SRAM0_BASE: usize = 0x0800_0000;
 const SRAM0_SIZE: usize = 0x0002_0000;
 const DRAM_BASE: usize = 0x4000_0000;
 
-// see also SiFive VICU7 manual chapter 6 (p 31)
-const CLINT_BASE_ADDR: usize = 0x0200_0000;
-const CLINT_HART1_MSIP: usize = CLINT_BASE_ADDR + 0x0004;
-const CLINT_HART2_MSIP: usize = CLINT_BASE_ADDR + 0x0008;
-const CLINT_HART3_MSIP: usize = CLINT_BASE_ADDR + 0x000c;
-const CLINT_HART4_MSIP: usize = CLINT_BASE_ADDR + 0x0010;
-
 // see https://doc-en.rvspace.org/JH7110/TRM/JH7110_TRM/system_memory_map.html
 const SPI_FLASH_BASE: usize = 0x2100_0000;
 
@@ -64,12 +57,6 @@ const LOAD_FROM_FLASH: bool = true;
 const DEBUG: bool = false;
 
 const STACK_SIZE: usize = 4 * 1024; // 4KiB
-
-/*
-const QSPI_CSR: usize = 0x1186_0000;
-const QSPI_READ_CMD: usize = QSPI_CSR + 0x0004;
-const SPI_FLASH_READ_CMD: u32 = 0x0003;
-*/
 
 #[link_section = ".bss.uninit"]
 static mut BT0_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
@@ -197,13 +184,6 @@ unsafe fn sleep(n: u32) {
     for _ in 0..n {
         core::hint::spin_loop();
     }
-}
-
-unsafe fn blink() {
-    sleep(0x0004_0000);
-    write32(init::GPIO40_43_DATA, 0x8181_8181);
-    sleep(0x0004_0000);
-    write32(init::GPIO40_43_DATA, 0x8080_8080);
 }
 
 static mut SERIAL: Option<uart::JH71XXSerial> = None;

--- a/src/mainboard/starfive/visionfive2/bt0/src/pac.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/pac.rs
@@ -1,0 +1,54 @@
+#[cfg(feature = "12a")]
+pub(crate) use jh71xx_pac::jh7110_vf2_12a_pac as pac;
+#[cfg(feature = "13b")]
+pub(crate) use jh71xx_pac::jh7110_vf2_13b_pac as pac;
+
+pub use pac::*;
+
+// SAFETY: this function is called during init, when only a single thread on a single core is
+// running, ensuring exclusive access.
+//
+// The reference must be dropped before calling again.
+pub(crate) fn syscrg_reg<'r>() -> &'r pac::syscrg::RegisterBlock {
+    unsafe { &*pac::SYSCRG::ptr() }
+}
+
+// SAFETY: this function is called during init, when only a single thread on a single core is
+// running, ensuring exclusive access.
+//
+// The reference must be dropped before calling again.
+pub(crate) fn aoncrg_reg<'r>() -> &'r pac::aoncrg::RegisterBlock {
+    unsafe { &*pac::AONCRG::ptr() }
+}
+
+// SAFETY: this function is called during init, when only a single thread on a single core is
+// running, ensuring exclusive access.
+//
+// The reference must be dropped before calling again.
+pub(crate) fn sys_syscon_reg<'r>() -> &'r pac::sys_syscon::RegisterBlock {
+    unsafe { &*pac::SYS_SYSCON::ptr() }
+}
+
+// SAFETY: this function is called during init, when only a single thread on a single core is
+// running, ensuring exclusive access.
+//
+// The reference must be dropped before calling again.
+pub(crate) fn uart0_reg<'r>() -> &'r pac::uart0::RegisterBlock {
+    unsafe { &*pac::UART0::ptr() }
+}
+
+// SAFETY: this function is called during init, when only a single thread on a single core is
+// running, ensuring exclusive access.
+//
+// The reference must be dropped before calling again.
+pub(crate) fn clint_reg<'r>() -> &'r pac::clint::RegisterBlock {
+    unsafe { &*pac::CLINT::ptr() }
+}
+
+// SAFETY: this function is called during init, when only a single thread on a single core is
+// running, ensuring exclusive access.
+//
+// The reference must be dropped before calling again.
+pub(crate) fn sys_pinctrl_reg<'r>() -> &'r pac::sys_pinctrl::RegisterBlock {
+    unsafe { &*pac::SYS_PINCTRL::ptr() }
+}

--- a/src/mainboard/starfive/visionfive2/bt0/src/pac.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/pac.rs
@@ -1,7 +1,4 @@
-#[cfg(feature = "12a")]
-pub(crate) use jh71xx_pac::jh7110_vf2_12a_pac as pac;
-#[cfg(feature = "13b")]
-pub(crate) use jh71xx_pac::jh7110_vf2_13b_pac as pac;
+pub(crate) use jh71xx_pac as pac;
 
 pub use pac::*;
 

--- a/src/mainboard/starfive/visionfive2/bt0/src/pll.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/pll.rs
@@ -1,4 +1,5 @@
-use crate::init::{self, pac, read32, udelay, write32};
+use crate::pac;
+use crate::init::{self, read32, udelay, write32};
 
 // see `boot/arch/riscv/cpu/jh7110/pll.c` `pll_set_rate`
 // NOTE: The order may be irrelevant, which would allow for simplification.
@@ -44,14 +45,8 @@ pub const PLL2_1188000000: PllFreq = PllFreq {
     dsmpd: 1,
 };
 
-// SAFETY: this function is called during init, when only a single thread on a single core is
-// running, ensuring exclusive access.
-fn sys_syscon_reg<'r>() -> &'r pac::sys_syscon::RegisterBlock {
-    unsafe { &*pac::SYS_SYSCON::ptr() }
-}
-
 pub fn pll0_set_freq(f: PllFreq) {
-    let syscon = sys_syscon_reg();
+    let syscon = pac::sys_syscon_reg();
 
     // NOTE: all register name offset values use zero-indexed, array-based numbering
     // This is in contrast to the address-offset numbering used in the TRM
@@ -84,7 +79,7 @@ pub fn pll0_set_freq(f: PllFreq) {
 // PLL1: 00b02603 55e00000 00c7a601
 // PLL1: 042a2603 41e00000 00c7a601
 pub fn pll1_set_freq(f: PllFreq) {
-    let syscon = sys_syscon_reg();
+    let syscon = pac::sys_syscon_reg();
 
     let v1 = syscon.sys_syscfg_9().read().bits();
     let v2 = syscon.sys_syscfg_8().read().bits();
@@ -121,7 +116,7 @@ pub fn pll1_set_freq(f: PllFreq) {
 }
 
 pub fn pll2_set_freq(f: PllFreq) {
-    let syscon = sys_syscon_reg();
+    let syscon = pac::sys_syscon_reg();
 
     // Turn PD off by setting the bit
     syscon.sys_syscfg_12().modify(|_, w| w.pll2_pd().set_bit());

--- a/src/mainboard/starfive/visionfive2/bt0/src/pll.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/pll.rs
@@ -1,5 +1,5 @@
-use crate::pac;
 use crate::init::{self, read32, udelay, write32};
+use crate::pac;
 
 // see `boot/arch/riscv/cpu/jh7110/pll.c` `pll_set_rate`
 // NOTE: The order may be irrelevant, which would allow for simplification.
@@ -52,15 +52,22 @@ pub fn pll0_set_freq(f: PllFreq) {
     // This is in contrast to the address-offset numbering used in the TRM
     // Basically, divide the TRM numbering by four to get the PAC numbering
 
-    // Turn off PD by setting the bit 
+    // Turn off PD by setting the bit
     syscon.sys_syscfg_8().modify(|_, w| w.pll0_pd().set_bit());
 
     syscon.sys_syscfg_6().modify(|_, w| {
-        w.pll0_dacpd().variant(f.dacpd != 0).pll0_dsmpd().variant(f.dsmpd != 0)
+        w.pll0_dacpd()
+            .variant(f.dacpd != 0)
+            .pll0_dsmpd()
+            .variant(f.dsmpd != 0)
     });
 
-    syscon.sys_syscfg_9().modify(|_, w| w.pll0_prediv().variant(f.prediv as u8));
-    syscon.sys_syscfg_7().modify(|_, w| w.pll0_fbdiv().variant(f.fbdiv as u16));
+    syscon
+        .sys_syscfg_9()
+        .modify(|_, w| w.pll0_prediv().variant(f.prediv as u8));
+    syscon
+        .sys_syscfg_7()
+        .modify(|_, w| w.pll0_fbdiv().variant(f.fbdiv as u16));
 
     // NOTE: Not sure why, but the original code does this shift, and defines
     // all postdiv values for all PLLs and config to be 1, effectively dropping
@@ -86,26 +93,35 @@ pub fn pll1_set_freq(f: PllFreq) {
     let v3 = syscon.sys_syscfg_11().read().bits();
     println!("PLL1: {v1:08x} {v2:08x} {v3:08x}");
 
-    // Turn off PD by setting the bit 
+    // Turn off PD by setting the bit
     syscon.sys_syscfg_10().modify(|_, w| w.pll1_pd().set_bit());
 
     syscon.sys_syscfg_9().modify(|_, w| {
-        w.pll1_dacpd().variant(f.dacpd !=0).pll1_dsmpd().variant(f.dsmpd != 0)
+        w.pll1_dacpd()
+            .variant(f.dacpd != 0)
+            .pll1_dsmpd()
+            .variant(f.dsmpd != 0)
     });
 
     let frac = 0xe00000;
-    syscon.sys_syscfg_10().modify(|_, w| w.pll1_frac().variant(frac));
+    syscon
+        .sys_syscfg_10()
+        .modify(|_, w| w.pll1_frac().variant(frac));
 
-    syscon.sys_syscfg_11().modify(|_, w| w.pll1_prediv().variant(f.prediv as u8));
+    syscon
+        .sys_syscfg_11()
+        .modify(|_, w| w.pll1_prediv().variant(f.prediv as u8));
 
-    syscon.sys_syscfg_9().modify(|_, w| w.pll1_fbdiv().variant(f.fbdiv as u16));
+    syscon
+        .sys_syscfg_9()
+        .modify(|_, w| w.pll1_fbdiv().variant(f.fbdiv as u16));
 
     // NOTE: Not sure why, but the original code does this shift, and defines
     // all postdiv values for all PLLs and config to be 1, effectively dropping
     // to 0 here.
-    syscon.sys_syscfg_10().modify(|_, w|{ 
+    syscon.sys_syscfg_10().modify(|_, w| {
         w.pll1_postdiv1().variant((f.postdiv1 >> 1) as u8);
-        // Turn on PD by clearing the bit 
+        // Turn on PD by clearing the bit
         w.pll1_pd().clear_bit()
     });
 
@@ -122,12 +138,19 @@ pub fn pll2_set_freq(f: PllFreq) {
     syscon.sys_syscfg_12().modify(|_, w| w.pll2_pd().set_bit());
 
     syscon.sys_syscfg_11().modify(|_, w| {
-        w.pll2_dacpd().variant(f.dacpd != 0).pll2_dsmpd().variant(f.dsmpd != 0)
+        w.pll2_dacpd()
+            .variant(f.dacpd != 0)
+            .pll2_dsmpd()
+            .variant(f.dsmpd != 0)
     });
 
-    syscon.sys_syscfg_13().modify(|_, w| w.pll2_prediv().variant(f.prediv as u8));
+    syscon
+        .sys_syscfg_13()
+        .modify(|_, w| w.pll2_prediv().variant(f.prediv as u8));
 
-    syscon.sys_syscfg_11().modify(|_, w| w.pll2_fbdiv().variant(f.fbdiv as u16));
+    syscon
+        .sys_syscfg_11()
+        .modify(|_, w| w.pll2_fbdiv().variant(f.fbdiv as u16));
 
     // NOTE: Not sure why, but the original code does this shift, and defines
     // all postdiv values for all PLLs and config to be 1, effectively dropping

--- a/src/mainboard/starfive/visionfive2/bt0/src/uart.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/uart.rs
@@ -5,13 +5,17 @@ use crate::pac;
 // UART0 Clock = clk_osc (24Mhz)
 const UART_CLK: u32 = 24_000_000;
 const UART_BAUDRATE_32MCLK_115200: u32 = 115200;
-const DIVISOR: u32 = UART_CLK.saturating_div(16).saturating_div(UART_BAUDRATE_32MCLK_115200);
+const DIVISOR: u32 = UART_CLK
+    .saturating_div(16)
+    .saturating_div(UART_BAUDRATE_32MCLK_115200);
 
 pub(crate) fn uart0_divisor() -> u16 {
     let uart0 = pac::uart0_reg();
 
     // Clear FIFOs to set UART0 to idle
-    uart0.fcr().modify(|_, w| w.rfifor().set_bit().xfifor().set_bit());
+    uart0
+        .fcr()
+        .modify(|_, w| w.rfifor().set_bit().xfifor().set_bit());
     while uart0.usr().read().busy().bit_is_set() {}
 
     uart0.lcr().modify(|_, w| w.dlab().set_bit());

--- a/src/mainboard/starfive/visionfive2/bt0/src/uart.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/uart.rs
@@ -1,67 +1,16 @@
-use core::ptr::{read_volatile, write_volatile};
 use log::{Error, Serial};
 
-// https://www.lammertbies.nl/comm/info/serial-uart
-const UART0_BASE: usize = 0x1000_0000;
+use crate::init::pac;
 
-pub const UART0_THR: usize = UART0_BASE + 0x0000; /* Transmitter holding reg. */
-const UART0_BRDL: usize = UART0_BASE + 0x0000; /* Baud rate divisor (LSB)  */
-const UART0_BRDH: usize = UART0_BASE + 0x0004; /* Baud rate divisor (MSB)  */
-const UART0_IER: usize = UART0_BASE + 0x0004; /* Interrupt enable reg.    */
-const UART0_IIR: usize = UART0_BASE + 0x0008; /* Interrupt ID reg.        */
-const UART0_FCR: usize = UART0_BASE + 0x0008; /* FIFO control reg.        */
-const UART0_LCR: usize = UART0_BASE + 0x000c; /* Line control reg.        */
-const UART0_MDC: usize = UART0_BASE + 0x0010; /* Modem control reg.       */
-const UART0_LSR: usize = UART0_BASE + 0x0014; /* Line status reg.         */
-
-/* constants for line control register */
-
-const LCR_CS8: u8 = 0x03; /* 8 bits data size */
-const LCR_1_STB: u8 = 0x00; /* 1 stop bit */
-const LCR_PEN: u8 = 0x08; /* parity enable */
-const LCR_PDIS: u8 = 0x00; /* parity disable */
-const LCR_EPS: u8 = 0x10; /* even parity select */
-const LCR_SP: u8 = 0x20; /* stick parity select */
-const LCR_SBRK: u8 = 0x40; /* break control bit */
-const LCR_DLAB: u8 = 0x80; /* divisor latch access enable */
-
-/* constants for line status register */
-
-const LSR_RXRDY: u8 = 0x01; /* receiver data available */
-const LSR_OE: u8 = 0x02; /* overrun error */
-const LSR_PE: u8 = 0x04; /* parity error */
-const LSR_FE: u8 = 0x08; /* framing error */
-const LSR_BI: u8 = 0x10; /* break interrupt */
-const LSR_EOB_MASK: u8 = 0x1E; /* Error or Break mask */
-const LSR_THRE: u8 = 0x20; /* transmit holding register empty */
-const LSR_TEMT: u8 = 0x40; /* transmitter empty */
-
-/* equates for FIFO control register */
-
-const FCR_FIFO: u8 = 0x01; /* enable XMIT and RCVR FIFO */
-const FCR_RCVRCLR: u8 = 0x02; /* clear RCVR FIFO */
-const FCR_XMITCLR: u8 = 0x04; /* clear XMIT FIFO */
-
-const FCR_MODE0: u8 = 0x00; /* set receiver in mode 0 */
-
-/* RCVR FIFO interrupt levels: trigger interrupt with this bytes in FIFO */
-const FCR_FIFO_8: u8 = 0x80; /* 8 bytes in RCVR FIFO */
-
-/*
-   FIXME: gotta figure out clocks and stuff...
-*/
-const UART_CLK: u32 = 100_000_000;
+// UART0 Clock = clk_osc (24Mhz)
+const UART_CLK: u32 = 24_000_000;
 const UART_BAUDRATE_32MCLK_115200: u32 = 115200;
-const DIVISOR: u32 = (UART_CLK / UART_BAUDRATE_32MCLK_115200) >> 4;
+const DIVISOR: u32 = UART_CLK.saturating_div(16).saturating_div(UART_BAUDRATE_32MCLK_115200);
 
-fn read_8(reg: usize) -> u8 {
-    unsafe { read_volatile(reg as *mut u8) }
-}
-
-fn write_8(reg: usize, val: u8) {
-    unsafe {
-        write_volatile(reg as *mut u8, val);
-    }
+// SAFETY: this function is called during init, when only a single thread on a single core is
+// running, ensuring exclusive access.
+pub(crate) fn uart0_reg<'r>() -> &'r pac::uart0::RegisterBlock {
+    unsafe { &*pac::UART0::ptr() }
 }
 
 #[derive(Debug)]
@@ -70,34 +19,44 @@ pub struct JH71XXSerial();
 impl JH71XXSerial {
     #[inline]
     pub fn new() -> Self {
-        let lcr_cache = read_8(UART0_LCR);
-        /* clear DLAB */
-        write_8(UART0_LCR, LCR_DLAB | lcr_cache);
+        let uart0 = uart0_reg();
+
+        /* wair for UART0 to stop being busy */
+        while uart0.usr().read().busy().bit_is_set() {}
+
+        /* set DLAB to access DLL/DLH registers */
+        uart0.lcr().modify(|_, w| w.dlab().set_bit());
         /* NOTE: Setting the divisor requires knowing the clock. */
-        /*
-        write_8(UART0_BRDL, DIVISOR as u8);
-        write_8(UART0_BRDH, (DIVISOR >> 8) as u8);
-        */
-        /* restore the DLAB to access the baud rate divisor registers */
-        write_8(UART0_LCR, lcr_cache);
+        uart0.dll().write(|w| w.dll().variant(DIVISOR as u8));
+        uart0.dlh().write(|w| w.dlh().variant((DIVISOR >> 8) as u8));
+        /* clear the DLAB to access the other UART0 registers */
+        uart0.lcr().modify(|_, w| w.dlab().clear_bit());
 
         /* 8 data bits, 1 stop bit, no parity */
-        write_8(UART0_LCR, LCR_CS8 | LCR_1_STB | LCR_PDIS);
+        uart0.lcr().modify(|_, w| {
+            w.dls().variant(0b11);
+            w.stop().clear_bit();
+            w.pen().clear_bit()
+        });
 
         /* disable flow control */
-        write_8(UART0_MDC, 0);
+        uart0.mcr().modify(|_, w| w.afce().clear_bit());
 
         /*
          * Program FIFO: enabled, mode 0 (set for compatibility with quark),
          * generate the interrupt at 8th byte
          * Clear TX and RX FIFO
          */
-        write_8(
-            UART0_FCR,
-            FCR_FIFO | FCR_MODE0 | FCR_FIFO_8 | FCR_RCVRCLR | FCR_XMITCLR,
-        );
+        uart0.fcr().modify(|_, w| {
+            w.fifoe().set_bit();
+            w.dmam().clear_bit();
+            // Trigger on the 8th byte
+            w.rt().variant(0b10);
+            w.rfifor().set_bit();
+            w.xfifor().set_bit()
+        });
 
-        write_8(UART0_IER, 0); // disable the serial interrupt
+        uart0.ier().modify(|_, w| w.ptime().clear_bit()); // disable the serial interrupt
 
         Self()
     }
@@ -112,10 +71,11 @@ impl embedded_hal_nb::serial::ErrorType for JH71XXSerial {
 impl embedded_hal_nb::serial::Write<u8> for JH71XXSerial {
     #[inline]
     fn write(&mut self, c: u8) -> nb::Result<(), self::Error> {
-        if read_8(UART0_LSR) & LSR_THRE == 0 {
+        let uart0 = uart0_reg();
+        if uart0.lsr().read().thre().bit_is_clear() {
             return Err(nb::Error::WouldBlock);
         }
-        write_8(UART0_THR, c);
+        uart0.thr().write(|w| w.thr().variant(c));
         Ok(())
     }
 


### PR DESCRIPTION
Uses the [`jh71xx-pac`](https://github.com/rmsyn/jh71xx-pac) library for peripheral access in the `Visionfive2` mainboard.