### PR TITLE
fixup: visionfive2: use Makefile `PORT` argument

### DIFF
--- a/src/mainboard/starfive/visionfive2/Makefile
+++ b/src/mainboard/starfive/visionfive2/Makefile
@@ -24,4 +24,4 @@ objdump: mainboard
 	riscv64-linux-gnu-objdump -D "$(IMAGE_BT0)"
 
 run: mainboard
-	sudo `which vf2-loader` $(IMAGE)
+	sudo `which vf2-loader` -D ${PORT} $(IMAGE)


### PR DESCRIPTION
Uses the supplied `PORT` Makefile variable as an argument to `vf2-loader`.