### PR TITLE
feature: visionfive2: use `jh71xx-hal` for peripheral access

### DIFF
--- a/src/lib/log/Cargo.toml
+++ b/src/lib/log/Cargo.toml
@@ -10,12 +10,7 @@ embedded-hal-nb = "=1.0.0"
 nb = "1"
 spin = "0.9"
 
-[dependencies.jh71xx-hal]
-version = "0.1"
-optional = true
-
 [features]
 default = []
 debug = []
 mutex = []
-jh71xx = ["jh71xx-hal/rt"]

--- a/src/lib/log/Cargo.toml
+++ b/src/lib/log/Cargo.toml
@@ -5,12 +5,17 @@ authors = ["oreboot Authors"]
 edition = "2021"
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.9"
-embedded-hal-nb = "=1.0.0-alpha.1"
+embedded-hal = "=1.0.0"
+embedded-hal-nb = "=1.0.0"
 nb = "1"
 spin = "0.9"
+
+[dependencies.jh71xx-hal]
+version = "0.1"
+optional = true
 
 [features]
 default = []
 debug = []
 mutex = []
+jh71xx = ["jh71xx-hal/rt"]

--- a/src/lib/log/src/lib.rs
+++ b/src/lib/log/src/lib.rs
@@ -103,12 +103,7 @@ impl embedded_hal_nb::serial::Error for Error {
     }
 }
 
-#[cfg(not(feature = "jh71xx"))]
 type SerialLogger = dyn Serial<Error = Error>;
-#[cfg(feature = "jh71xx")]
-type SerialLogger = dyn Serial<Error = jh71xx_hal::uart::Error>;
-#[cfg(feature = "jh71xx")]
-impl<UART: jh71xx_hal::uart::Serial> Serial for jh71xx_hal::uart::Uart<UART> {}
 
 #[cfg(feature = "mutex")]
 static LOGGER: spin::Mutex<Option<&'static mut SerialLogger>> = spin::Mutex::new(None);
@@ -125,7 +120,6 @@ impl fmt::Write for SerialLogger {
             }
             block!(self.write(byte)).ok();
         }
-        #[cfg(not(feature = "jh71xx"))]
         block!(self.flush()).ok();
         Ok(())
     }

--- a/src/lib/log/src/lib.rs
+++ b/src/lib/log/src/lib.rs
@@ -121,12 +121,12 @@ impl fmt::Write for SerialLogger {
         for &byte in s.as_bytes() {
             // Inject a carriage return before a newline
             if byte == b'\n' {
-                block!(self.write(b'\r')).unwrap();
+                block!(self.write(b'\r')).ok();
             }
-            block!(self.write(byte)).unwrap();
+            block!(self.write(byte)).ok();
         }
         #[cfg(not(feature = "jh71xx"))]
-        block!(self.flush()).unwrap();
+        block!(self.flush()).ok();
         Ok(())
     }
 }
@@ -135,11 +135,13 @@ impl fmt::Write for SerialLogger {
 pub fn print(args: fmt::Arguments) {
     use fmt::Write;
     #[cfg(feature = "mutex")]
-    LOGGER.lock().as_mut().unwrap().write_fmt(args).unwrap();
+    if let Ok(l) = LOGGER.lock().as_mut() {
+        l.write_fmt(args).ok();
+    }
     #[cfg(not(feature = "mutex"))]
     unsafe {
         if let Some(l) = LOGGER.as_mut() {
-            l.write_fmt(args).unwrap();
+            l.write_fmt(args).ok();
         }
     }
 }

--- a/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
+++ b/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
@@ -16,7 +16,7 @@ riscv = "0.10.1"
 spin = "0.9"
 
 layoutflash = { path = "../../../../lib/layoutflash" }
-log = { path = "../../../../lib/log", features = ["jh71xx"] }
+log = { path = "../../../../lib/log" }
 
 [dependencies.jh71xx-hal]
 version = "0.1"

--- a/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
+++ b/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
@@ -7,8 +7,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-embedded-hal = "1.0.0-alpha.9"
-embedded-hal-nb = "1.0.0-alpha.1"
+embedded-hal = "1.0.0"
+embedded-hal-nb = "1.0.0"
 fdt = "0.1.4"
 jh71xx-pac = "0.3"
 nb = "1"
@@ -16,4 +16,8 @@ riscv = "0.10.1"
 spin = "0.9"
 
 layoutflash = { path = "../../../../lib/layoutflash" }
-log = { path = "../../../../lib/log" }
+log = { path = "../../../../lib/log", features = ["jh71xx"] }
+
+[dependencies.jh71xx-hal]
+version = "0.1"
+features = ["rt"]

--- a/src/mainboard/starfive/visionfive2/bt0/build.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/build.rs
@@ -12,7 +12,6 @@ OUTPUT_ARCH(riscv)
 ENTRY(_start)
 MEMORY {
     SRAM : ORIGIN = 0x08000000, LENGTH = 128k
-    # DRAM : ORIGIN = 0x80000000, LENGTH = 8G
 }
 SECTIONS {
     .head : {

--- a/src/mainboard/starfive/visionfive2/bt0/src/main.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/main.rs
@@ -281,12 +281,12 @@ fn main() {
         w.doen_6().variant(0b1)
     });
 
-    pac::sys_pinctrl_reg().gpo_dout_1().modify(|_, w| {
-        w.dout_5().variant(20)
-    });
-    pac::sys_pinctrl_reg().gpi_3().modify(|_, w| {
-        w.uart_sin_0().variant(6)
-    });
+    pac::sys_pinctrl_reg()
+        .gpo_dout_1()
+        .modify(|_, w| w.dout_5().variant(20));
+    pac::sys_pinctrl_reg()
+        .gpi_3()
+        .modify(|_, w| w.uart_sin_0().variant(6));
 
     let dp = pac::Peripherals::take().unwrap();
 
@@ -299,7 +299,7 @@ fn main() {
             parity: hal::uart::Parity::None,
             baud_rate: hal::uart::BaudRate::B115200,
             clk_hz: uart::UART_CLK,
-        }
+        },
     );
 
     init_logger(s);

--- a/src/mainboard/starfive/visionfive2/bt0/src/pac.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/pac.rs
@@ -1,4 +1,4 @@
-pub(crate) use jh71xx_pac as pac;
+pub(crate) use jh71xx_hal::pac;
 
 pub use pac::*;
 
@@ -48,4 +48,12 @@ pub(crate) fn clint_reg<'r>() -> &'r pac::clint::RegisterBlock {
 // The reference must be dropped before calling again.
 pub(crate) fn sys_pinctrl_reg<'r>() -> &'r pac::sys_pinctrl::RegisterBlock {
     unsafe { &*pac::SYS_PINCTRL::ptr() }
+}
+
+// SAFETY: this function is called during init, when only a single thread on a single core is
+// running, ensuring exclusive access.
+//
+// The reference must be dropped before calling again.
+pub(crate) fn plic_reg<'r>() -> &'r pac::plic::RegisterBlock {
+    unsafe { &*pac::PLIC::ptr() }
 }

--- a/src/mainboard/starfive/visionfive2/bt0/src/uart.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/uart.rs
@@ -1,8 +1,51 @@
+use embedded_hal_nb::serial::{Error as _, ErrorType, Read, Write};
 use log::{Error, Serial};
 
 use crate::pac;
 
-pub type JH71XXSerial = jh71xx_hal::uart::Uart<pac::UART0>;
+pub use jh71xx_hal::uart::Config;
+use jh71xx_hal::uart::Uart;
+
+/// Wrapper around the [`jh71xx_hal::uart::Uart`] UART peripheral type.
+pub struct JH71XXSerial(jh71xx_hal::uart::Uart<pac::UART0>);
+
+impl JH71XXSerial {
+    /// Creates a new [JH71XXSerial] with a custom configuration.
+    pub fn new_with_config(mut uart: pac::UART0, timeout: u64, config: Config) -> Self {
+        Self(Uart::new_with_config(uart, timeout, config))
+    }
+}
+
+impl Serial for JH71XXSerial {}
+
+impl ErrorType for JH71XXSerial {
+    type Error = Error;
+}
+
+impl Read for JH71XXSerial {
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        self.0.read().map_err(|err| match err {
+            nb::Error::Other(e) => nb::Error::Other(Error { kind: e.kind() }),
+            nb::Error::WouldBlock => nb::Error::WouldBlock,
+        })
+    }
+}
+
+impl Write for JH71XXSerial {
+    fn write(&mut self, val: u8) -> nb::Result<(), Self::Error> {
+        self.0.write(val).map_err(|err| match err {
+            nb::Error::Other(e) => nb::Error::Other(Error { kind: e.kind() }),
+            nb::Error::WouldBlock => nb::Error::WouldBlock,
+        })
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        self.0.flush().map_err(|err| match err {
+            nb::Error::Other(e) => nb::Error::Other(Error { kind: e.kind() }),
+            nb::Error::WouldBlock => nb::Error::WouldBlock,
+        })
+    }
+}
 
 // UART0 Clock = clk_osc (24Mhz)
 pub const UART_CLK: usize = 24_000_000;

--- a/src/mainboard/starfive/visionfive2/bt0/src/uart.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/uart.rs
@@ -2,12 +2,10 @@ use log::{Error, Serial};
 
 use crate::pac;
 
+pub type JH71XXSerial = jh71xx_hal::uart::Uart<pac::UART0>;
+
 // UART0 Clock = clk_osc (24Mhz)
-const UART_CLK: u32 = 24_000_000;
-const UART_BAUDRATE_32MCLK_115200: u32 = 115200;
-const DIVISOR: u32 = UART_CLK
-    .saturating_div(16)
-    .saturating_div(UART_BAUDRATE_32MCLK_115200);
+pub const UART_CLK: usize = 24_000_000;
 
 pub(crate) fn uart0_divisor() -> u16 {
     let uart0 = pac::uart0_reg();
@@ -23,81 +21,4 @@ pub(crate) fn uart0_divisor() -> u16 {
     uart0.lcr().modify(|_, w| w.dlab().clear_bit());
 
     div as u16
-}
-
-#[derive(Debug)]
-pub struct JH71XXSerial();
-
-impl JH71XXSerial {
-    #[inline]
-    pub fn new() -> Self {
-        let uart0 = pac::uart0_reg();
-
-        /* wair for UART0 to stop being busy */
-        while uart0.usr().read().busy().bit_is_set() {}
-
-        /* set DLAB to access DLL/DLH registers */
-        uart0.lcr().modify(|_, w| w.dlab().set_bit());
-        /* NOTE: Setting the divisor requires knowing the clock. */
-        uart0.dll().write(|w| w.dll().variant(DIVISOR as u8));
-        uart0.dlh().write(|w| w.dlh().variant((DIVISOR >> 8) as u8));
-        /* clear the DLAB to access the other UART0 registers */
-        uart0.lcr().modify(|_, w| w.dlab().clear_bit());
-
-        /* 8 data bits, 1 stop bit, no parity */
-        uart0.lcr().modify(|_, w| {
-            w.dls().variant(0b11);
-            w.stop().clear_bit();
-            w.pen().clear_bit()
-        });
-
-        /* disable flow control */
-        uart0.mcr().modify(|_, w| w.afce().clear_bit());
-
-        /*
-         * Program FIFO: enabled, mode 0 (set for compatibility with quark),
-         * generate the interrupt at 8th byte
-         * Clear TX and RX FIFO
-         */
-        uart0.fcr().modify(|_, w| {
-            w.fifoe().set_bit();
-            w.dmam().clear_bit();
-            // Trigger on the 8th byte
-            w.rt().variant(0b10);
-            w.rfifor().set_bit();
-            w.xfifor().set_bit()
-        });
-
-        uart0.ier().modify(|_, w| w.ptime().clear_bit()); // disable the serial interrupt
-
-        Self()
-    }
-}
-
-impl Serial for JH71XXSerial {}
-
-impl embedded_hal_nb::serial::ErrorType for JH71XXSerial {
-    type Error = Error;
-}
-
-impl embedded_hal_nb::serial::Write<u8> for JH71XXSerial {
-    #[inline]
-    fn write(&mut self, c: u8) -> nb::Result<(), self::Error> {
-        let uart0 = pac::uart0_reg();
-        if uart0.lsr().read().thre().bit_is_clear() {
-            return Err(nb::Error::WouldBlock);
-        }
-        uart0.thr().write(|w| w.thr().variant(c));
-        Ok(())
-    }
-
-    #[inline]
-    fn flush(&mut self) -> nb::Result<(), self::Error> {
-        let tfe_empty = true;
-        if tfe_empty {
-            Ok(())
-        } else {
-            Err(nb::Error::WouldBlock)
-        }
-    }
 }

--- a/src/mainboard/starfive/visionfive2/main/Cargo.toml
+++ b/src/mainboard/starfive/visionfive2/main/Cargo.toml
@@ -9,8 +9,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-embedded-hal = "1.0.0-alpha.9"
-embedded-hal-nb = "1.0.0-alpha.1"
+embedded-hal = "1.0.0"
+embedded-hal-nb = "1.0.0"
 nb = "1"
 riscv = "0.10.1"
 spin = "0.9"

--- a/src/mainboard/sunxi/nezha/bt0/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/bt0/Cargo.toml
@@ -9,8 +9,8 @@ authors = [
 edition = "2021"
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.9"
-embedded-hal-nb = "=1.0.0-alpha.1"
+embedded-hal = "=1.0.0"
+embedded-hal-nb = "=1.0.0"
 log = { path = "../../../../lib/log" }
 nb = "1"
 spin = "0.9"

--- a/src/mainboard/sunxi/nezha/main/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/main/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 bitflags = "1"
-embedded-hal = "=1.0.0-alpha.9"
-embedded-hal-nb = "=1.0.0-alpha.1"
+embedded-hal = "=1.0.0"
+embedded-hal-nb = "=1.0.0"
 lazy_static = { version = "1", features = ["spin_no_std"] }
 nb = "1"
 riscv = { version = "0.10.0", features = ["critical-section-single-hart"] }

--- a/src/soc/src/sunxi/d1/gpio.rs
+++ b/src/soc/src/sunxi/d1/gpio.rs
@@ -246,11 +246,11 @@ impl<const P: char, const N: u8> embedded_hal::digital::ErrorType for Pin<P, N, 
 
 impl<const P: char, const N: u8> embedded_hal::digital::InputPin for Pin<P, N, Input> {
     #[inline]
-    fn is_high(&self) -> Result<bool, Self::Error> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
         Ok(unsafe { read_volatile(Self::DATA_REG) } & (1 << N) != 0)
     }
     #[inline]
-    fn is_low(&self) -> Result<bool, Self::Error> {
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
         Ok(unsafe { read_volatile(Self::DATA_REG) } & (1 << N) == 0)
     }
 }
@@ -278,11 +278,11 @@ impl<const P: char, const N: u8> embedded_hal::digital::OutputPin for Pin<P, N, 
 
 impl<const P: char, const N: u8> embedded_hal::digital::StatefulOutputPin for Pin<P, N, Output> {
     #[inline]
-    fn is_set_high(&self) -> Result<bool, Self::Error> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
         Ok(unsafe { read_volatile(Self::DATA_REG) } & (1 << N) != 0)
     }
     #[inline]
-    fn is_set_low(&self) -> Result<bool, Self::Error> {
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
         Ok(unsafe { read_volatile(Self::DATA_REG) } & (1 << N) == 0)
     }
 }


### PR DESCRIPTION
Uses the [`jh71xx-hal`](https://github.com/rmsyn/jh71xx-hal) crate for peripheral access, mainly the `UART0` peripheral.

The `jh71xx-hal` is currently a work-in-progress. Most notably, the `interrupt` code around `PLIC` configuration is apparently broken. The GPIO code also requires a big rewrite to match code from other `embedded-hal` implementations.

Depends on the changes in https://github.com/oreboot/oreboot/pull/713