### PR TITLE
Upgrade Rust to nightly-2024-01-10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,11 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  QuickFormat:
-    runs-on: ubuntu-latest
-    steps:
-      - name: git-checkout-action
-        uses: actions/checkout@v3
-      - name: dprint-check-action
-        uses: dprint/check@v2.2
-
   LintAndFormat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: 'checkout'
+        uses: actions/checkout@v3
       - name: 'Install Dependencies'
         run: sudo apt-get update && make ciprepare
       - name: 'clippy linter'
@@ -34,10 +27,10 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: 'checkout'
+        uses: actions/checkout@v3
       - name: 'Install Dependencies'
-        run: |
-          sudo apt-get update && make ciprepare
+        run: sudo apt-get update && make ciprepare
       - name: 'Create coverage file'
         run: make --keep-going citest
       - name: 'upload the coverage file to server'
@@ -48,7 +41,8 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: 'checkout'
+        uses: actions/checkout@v3
       - name: 'Install Dependencies'
         run: sudo apt-get update && make ciprepare
       - name: 'Build all mainboards'

--- a/dprint.json
+++ b/dprint.json
@@ -18,9 +18,9 @@
     "3rdparty/"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/exec-0.4.3.json@42343548b8022c99b1d750be6b894fe6b6c7ee25f72ae9f9082226dd2e515072",
-    "https://plugins.dprint.dev/json-0.17.1.wasm",
-    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
+    "https://plugins.dprint.dev/exec-0.4.4.json@c207bf9b9a4ee1f0ecb75c594f774924baf62e8e53a2ce9d873816a408cecbf7",
+    "https://plugins.dprint.dev/json-0.19.1.wasm",
+    "https://plugins.dprint.dev/markdown-0.16.3.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm"
   ]
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,11 +1,7 @@
 [toolchain]
-channel = "nightly-2023-10-13"
-components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]
+channel = "nightly-2024-01-10"
+components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]
 targets = [
-  "aarch64-unknown-none-softfloat",
-  "armv7a-none-eabi",
-  "powerpc64-unknown-linux-gnu",
-  "powerpc64le-unknown-linux-gnu",
   "riscv32imac-unknown-none-elf",
   "riscv64imac-unknown-none-elf",
 ]

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(asm_const)]
 #![feature(naked_functions)]
-#![feature(generator_trait)]
+#![feature(coroutine_trait)]
 #![no_std]
 
 #[cfg(feature = "riscv64")]

--- a/src/arch/src/riscv64/sbi/runtime.rs
+++ b/src/arch/src/riscv64/sbi/runtime.rs
@@ -1,6 +1,6 @@
 use core::{
     arch::asm,
-    ops::{Generator, GeneratorState},
+    ops::{Coroutine, CoroutineState},
     pin::Pin,
 };
 use log::println;
@@ -94,10 +94,10 @@ fn crap() {
     );
 }
 
-impl Generator for Runtime {
+impl Coroutine for Runtime {
     type Yield = MachineTrap;
     type Return = ();
-    fn resume(mut self: Pin<&mut Self>, _arg: ()) -> GeneratorState<Self::Yield, Self::Return> {
+    fn resume(mut self: Pin<&mut Self>, _arg: ()) -> CoroutineState<Self::Yield, Self::Return> {
         unsafe { do_resume(&mut self.context as *mut _) };
         let mtval = mtval::read();
         let trap = match mcause::read().cause() {
@@ -124,7 +124,7 @@ impl Generator for Runtime {
                 e, mtval, self.context
             ),
         };
-        GeneratorState::Yielded(trap)
+        CoroutineState::Yielded(trap)
     }
 }
 

--- a/src/lib/log/src/lib.rs
+++ b/src/lib/log/src/lib.rs
@@ -132,7 +132,7 @@ pub fn print(args: fmt::Arguments) {
     LOGGER.lock().as_mut().unwrap().write_fmt(args).unwrap();
     #[cfg(not(feature = "mutex"))]
     unsafe {
-        if let Some(l) = &mut LOGGER {
+        if let Some(l) = LOGGER.as_mut() {
             l.write_fmt(args).unwrap();
         }
     }

--- a/src/mainboard/starfive/visionfive2/bt0/src/main.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/main.rs
@@ -9,7 +9,12 @@ extern crate log;
 extern crate layoutflash;
 use layoutflash::areas::{find_fdt, FdtIterator};
 
-use core::{arch::asm, intrinsics::transmute, panic::PanicInfo, ptr};
+use core::{
+    arch::asm,
+    intrinsics::transmute,
+    panic::PanicInfo,
+    ptr::{self, addr_of, addr_of_mut},
+};
 use init::{dump_block, read32, write32};
 use riscv::register::mhartid;
 use riscv::register::{marchid, mimpid, mvendorid};
@@ -127,11 +132,11 @@ pub unsafe extern "C" fn reset() {
         static _sidata: u8;
     }
 
-    let count = &_ebss as *const u8 as usize - &_sbss as *const u8 as usize;
-    ptr::write_bytes(&mut _sbss as *mut u8, 0, count);
+    let count = addr_of!(_ebss) as usize - addr_of!(_sbss) as usize;
+    ptr::write_bytes(addr_of_mut!(_sbss), 0, count);
 
-    let count = &_edata as *const u8 as usize - &_sdata as *const u8 as usize;
-    ptr::copy_nonoverlapping(&_sidata as *const u8, &mut _sdata as *mut u8, count);
+    let count = addr_of!(_edata) as usize - addr_of!(_sdata) as usize;
+    ptr::copy_nonoverlapping(addr_of!(_sidata), addr_of_mut!(_sdata), count);
     // Call user entry point
     main();
 }

--- a/src/mainboard/sunxi/nezha/main/src/main.rs
+++ b/src/mainboard/sunxi/nezha/main/src/main.rs
@@ -2,7 +2,6 @@
 #![no_main]
 #![feature(naked_functions)]
 #![feature(asm_const)]
-#![feature(generator_trait)]
 #![feature(panic_info_message)]
 
 use core::panic::PanicInfo;


### PR DESCRIPTION
Signed-off-by: Daniel Maslowski <info@orangecms.org>

Drop the Arm and PPC toolchains for now. They are not used and only waste space at this point.