### PR TITLE
feature: vf2: use `jh71xx-pac` for DDR configuration

### DIFF
--- a/src/mainboard/starfive/visionfive2/bt0/src/ddr_start.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/ddr_start.rs
@@ -313,30 +313,25 @@ pub unsafe fn start() {
     let phy = &*pac::DMC_PHY::ptr();
 
     START_CFG0.iter().for_each(|cfg| {
-        phy.ac_base(cfg.reg_nr as usize).modify(|r, w| {
-            w.bits((r.bits() & cfg.mask) | cfg.value)
-        });
+        phy.ac_base(cfg.reg_nr as usize)
+            .modify(|r, w| w.bits((r.bits() & cfg.mask) | cfg.value));
     });
     START_CFG1.iter().for_each(|cfg| {
-        phy.base(cfg.reg_nr as usize).modify(|r, w| {
-            w.bits((r.bits() & cfg.mask) | cfg.value)
-        });
+        phy.base(cfg.reg_nr as usize)
+            .modify(|r, w| w.bits((r.bits() & cfg.mask) | cfg.value));
     });
     // NOTE: Commented out in VF1 code
     if cfg!(dram_size = "2G") {
-        phy.base(11).modify(|r, w| {
-            w.bits((r.bits() & 0xffff_fff0) | 0x0000_0005)
-        });
+        phy.base(11)
+            .modify(|r, w| w.bits((r.bits() & 0xffff_fff0) | 0x0000_0005));
     }
     START_CFG2.iter().for_each(|cfg| {
-        phy.base(cfg.reg_nr as usize).modify(|r, w| {
-            w.bits((r.bits() & cfg.mask) | cfg.value)
-        });
+        phy.base(cfg.reg_nr as usize)
+            .modify(|r, w| w.bits((r.bits() & cfg.mask) | cfg.value));
     });
     START_CFG3.iter().for_each(|cfg| {
-        phy.ac_base(cfg.reg_nr as usize).modify(|r, w| {
-            w.bits((r.bits() & cfg.mask) | cfg.value)
-        });
+        phy.ac_base(cfg.reg_nr as usize)
+            .modify(|r, w| w.bits((r.bits() & cfg.mask) | cfg.value));
     });
     // PHY_RPTR_UPDATE_x: bit[11:8]+=3
     // NOTE: Special handling: write back current val + val to register
@@ -355,31 +350,29 @@ pub unsafe fn start() {
     //    G_SPEED_3200: 0x00180000
     // TODO: try lower speed?
     [96, 352, 608, 864].iter().for_each(|&reg| {
-        phy.ac_base(reg).modify(|r, w| {
-            w.bits((r.bits() & 0xff00_ffff) | 0x0012_0000)
-        });
+        phy.ac_base(reg)
+            .modify(|r, w| w.bits((r.bits() & 0xff00_ffff) | 0x0012_0000));
     });
 
     START_CFG4.iter().for_each(|cfg| {
-        phy.ac_base(cfg.reg_nr as usize).modify(|r, w| {
-            w.bits((r.bits() & cfg.mask) | cfg.value)
-        });
+        phy.ac_base(cfg.reg_nr as usize)
+            .modify(|r, w| w.bits((r.bits() & cfg.mask) | cfg.value));
     });
     START_CFG5.iter().for_each(|cfg| {
-        phy.ac_base(cfg.reg_nr as usize).write(|w| w.bits(cfg.value));
+        phy.ac_base(cfg.reg_nr as usize)
+            .write(|w| w.bits(cfg.value));
     });
     START_CFG6.iter().for_each(|cfg| {
-        phy.ac_base(cfg.reg_nr as usize).modify(|r, w| {
-            w.bits((r.bits() & cfg.mask) | cfg.value)
-        });
+        phy.ac_base(cfg.reg_nr as usize)
+            .modify(|r, w| w.bits((r.bits() & cfg.mask) | cfg.value));
     });
     START_CFG7.iter().for_each(|cfg| {
-        phy.ac_base(cfg.reg_nr as usize).write(|w| w.bits(cfg.value));
+        phy.ac_base(cfg.reg_nr as usize)
+            .write(|w| w.bits(cfg.value));
     });
     START_CFG8.iter().for_each(|cfg| {
-        phy.ac_base(cfg.reg_nr as usize).modify(|r, w| {
-            w.bits((r.bits() & cfg.mask) | cfg.value)
-        });
+        phy.ac_base(cfg.reg_nr as usize)
+            .modify(|r, w| w.bits((r.bits() & cfg.mask) | cfg.value));
     });
     phy.csr(0).write(|w| w.bits(0x1));
 }

--- a/src/mainboard/starfive/visionfive2/bt0/src/ddr_start.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/ddr_start.rs
@@ -309,7 +309,7 @@ const START_CFG8: [MemCfg; 25] = crate::ddrlib::mem_cfg_arr![
 
 const DEBUG: bool = false;
 
-pub unsafe fn start(phy_base: usize, phy_ctrl_base: usize, phy_ac_base: usize) {
+pub unsafe fn start() {
     let phy = &*pac::DMC_PHY::ptr();
 
     START_CFG0.iter().for_each(|cfg| {

--- a/src/mainboard/starfive/visionfive2/bt0/src/ddrcsr.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/ddrcsr.rs
@@ -12,7 +12,7 @@ const TRAINING_STATUS_MAYBE: usize = 0x0518;
 
 const VERBOSE: bool = false;
 
-fn train(phy_base: usize, training_status_reg: usize) {
+fn train(training_status_reg: usize) {
     let mut rounds: usize = 0;
     let freq_change_req = FREQ_CHANGE;
     let phy = unsafe { &*pac::DMC_PHY::ptr() };
@@ -316,12 +316,7 @@ const DDR_CSR_CFG5: [MemSet; 6] = mem_set_arr![
 ];
 
 // NOTE: `reg_nr` here is actually the _offset_! So do not shift << 2.
-pub unsafe fn omc_init(
-    phy_base: usize,
-    cfg_base_addr: usize,
-    sec_base_addr: usize,
-    phy_ctrl_base: usize,
-) {
+pub unsafe fn omc_init() {
     println!("[DRAM] OMC init");
     let ctrl = &*pac::DMC_CTRL::ptr();
     let phy = &*pac::DMC_PHY::ptr();
@@ -397,7 +392,7 @@ pub unsafe fn omc_init(
     }
 
     println!("[DRAM] OMC init train");
-    train(phy_base, TRAINING_STATUS_MAYBE);
+    train(TRAINING_STATUS_MAYBE);
 
     println!("[DRAM] OMC init PHY");
     // NOTE: This here even worked when I was accidentally off to 0x150 / 0x154.

--- a/src/mainboard/starfive/visionfive2/bt0/src/ddrcsr.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/ddrcsr.rs
@@ -323,7 +323,8 @@ pub unsafe fn omc_init() {
     ctrl.csr(0).write(|w| w.bits(0x1));
 
     DDR_CSR_CFG0.iter().for_each(|cfg| {
-        ctrl.sec((cfg.reg_nr >> 2) as usize).write(|w| w.bits(cfg.value));
+        ctrl.sec((cfg.reg_nr >> 2) as usize)
+            .write(|w| w.bits(cfg.value));
     });
     if cfg!(dram_size = "8G") || cfg!(dram_size = "4G") {
         ctrl.sec(0xf34 >> 2).write(|w| w.bits(0x1f00_0041));
@@ -334,7 +335,8 @@ pub unsafe fn omc_init() {
     ctrl.sec(0x0114 >> 2).write(|w| w.bits(0xffff_ffff));
 
     DDR_CSR_CFG1.iter().for_each(|cfg| {
-        ctrl.csr((cfg.reg_nr >> 2) as usize).write(|w| w.bits(cfg.value));
+        ctrl.csr((cfg.reg_nr >> 2) as usize)
+            .write(|w| w.bits(cfg.value));
     });
 
     // This seems to trigger some sort of readiness.
@@ -366,7 +368,8 @@ pub unsafe fn omc_init() {
     // Waits tINIT5 (2 us): Minimum idle time before first MRW/MRR command
     udelay(4);
     DDR_CSR_CFG2.iter().for_each(|cfg| {
-        ctrl.csr((cfg.reg_nr >> 2) as usize).write(|w| w.bits(cfg.value));
+        ctrl.csr((cfg.reg_nr >> 2) as usize)
+            .write(|w| w.bits(cfg.value));
     });
     // Waits tZQCAL (1 us)
     udelay(4);
@@ -387,7 +390,10 @@ pub unsafe fn omc_init() {
     // and then, that training is done. See the train() function using the same
     // mask again.
     while ctrl.csr(TRAINING_STATUS_MAYBE >> 2).read().bits() & 0x2 != 0x2 {
-        println!("[DRAM] Training status maybe value: {}", ctrl.csr(TRAINING_STATUS_MAYBE >> 2).read().bits());
+        println!(
+            "[DRAM] Training status maybe value: {}",
+            ctrl.csr(TRAINING_STATUS_MAYBE >> 2).read().bits()
+        );
         udelay(1);
     }
 
@@ -401,17 +407,18 @@ pub unsafe fn omc_init() {
     phy.base(81).write(|w| w.bits(val & 0xF800_0000));
 
     DDR_CSR_CFG3.iter().for_each(|cfg| {
-        phy.base((cfg.reg_nr >> 2) as usize).modify(|r, w| {
-            w.bits((r.bits() & cfg.mask) | cfg.value)
-        });
+        phy.base((cfg.reg_nr >> 2) as usize)
+            .modify(|r, w| w.bits((r.bits() & cfg.mask) | cfg.value));
     });
 
     DDR_CSR_CFG4.iter().for_each(|cfg| {
-        ctrl.csr((cfg.reg_nr >> 2) as usize).write(|w| w.bits(cfg.value));
+        ctrl.csr((cfg.reg_nr >> 2) as usize)
+            .write(|w| w.bits(cfg.value));
     });
     ctrl.sec(0x0704 >> 2).write(|w| w.bits(0x0000_0007));
     DDR_CSR_CFG5.iter().for_each(|cfg| {
-        ctrl.csr((cfg.reg_nr >> 2) as usize).write(|w| w.bits(cfg.value));
+        ctrl.csr((cfg.reg_nr >> 2) as usize)
+            .write(|w| w.bits(cfg.value));
     });
     ctrl.sec(0x0700 >> 2).write(|w| w.bits(0x0000_0003));
     ctrl.csr(0x0514 >> 2).write(|w| w.bits(0x0000_0600));

--- a/src/mainboard/starfive/visionfive2/bt0/src/ddrphy.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/ddrphy.rs
@@ -512,7 +512,7 @@ const UTIL_DATA2: [u32; 139] = [
     0x200400,   //
 ];
 
-pub fn train(base_addr: usize) {
+pub fn train() {
     let phy = unsafe { &*pac::DMC_PHY::ptr() };
     TRAIN_DATA.iter().enumerate().for_each(|(reg_nr, &value)| {
         phy.base(reg_nr).write(|w| unsafe { w.bits(value) });
@@ -592,7 +592,7 @@ fn util_data1_b(base: usize, v1: u32, v2: u32, v3: u32) {
 
 // First, we write everything from register 1792 on, then everything up to 1792.
 // We do not know why, just copied it from the reference implementation.
-pub fn util(base_addr: usize) {
+pub fn util() {
     let phy = unsafe { &*pac::DMC_PHY::ptr() };
     UTIL_DATA2.iter().enumerate().for_each(|(reg_nr, &value)| {
         phy.ac_base(1792 + reg_nr).write(|w| unsafe { w.bits(value) });

--- a/src/mainboard/starfive/visionfive2/bt0/src/ddrphy.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/ddrphy.rs
@@ -544,14 +544,16 @@ fn util_data1_a(base: usize, v1: u32) {
         .iter()
         .enumerate()
         .for_each(|(reg_nr, &value)| {
-            phy.ac_base(base + reg_nr).write(|w| unsafe { w.bits(value) });
+            phy.ac_base(base + reg_nr)
+                .write(|w| unsafe { w.bits(value) });
         });
     phy.ac_base(base + 44).write(|w| unsafe { w.bits(v1) });
     UTIL_DATA1_A2
         .iter()
         .enumerate()
         .for_each(|(reg_nr, &value)| {
-            phy.ac_base(base + 45 + reg_nr).write(|w| unsafe { w.bits(value) });
+            phy.ac_base(base + 45 + reg_nr)
+                .write(|w| unsafe { w.bits(value) });
         });
     for r in 131..256 {
         phy.ac_base(base + r).write(|w| unsafe { w.bits(0) })
@@ -574,7 +576,8 @@ fn util_data1_b(base: usize, v1: u32, v2: u32, v3: u32) {
         .iter()
         .enumerate()
         .for_each(|(reg_nr, &value)| {
-            phy.ac_base(base + reg_nr).write(|w| unsafe { w.bits(value) });
+            phy.ac_base(base + reg_nr)
+                .write(|w| unsafe { w.bits(value) });
         });
     phy.ac_base(base + 30).write(|w| unsafe { w.bits(v1) });
     phy.ac_base(base + 31).write(|w| unsafe { w.bits(v2) });
@@ -583,7 +586,8 @@ fn util_data1_b(base: usize, v1: u32, v2: u32, v3: u32) {
         .iter()
         .enumerate()
         .for_each(|(reg_nr, &value)| {
-            phy.ac_base(base + 33 + reg_nr).write(|w| unsafe { w.bits(value) });
+            phy.ac_base(base + 33 + reg_nr)
+                .write(|w| unsafe { w.bits(value) });
         });
     for r in 49..256 {
         phy.ac_base(base + r).write(|w| unsafe { w.bits(0) });
@@ -595,7 +599,8 @@ fn util_data1_b(base: usize, v1: u32, v2: u32, v3: u32) {
 pub fn util() {
     let phy = unsafe { &*pac::DMC_PHY::ptr() };
     UTIL_DATA2.iter().enumerate().for_each(|(reg_nr, &value)| {
-        phy.ac_base(1792 + reg_nr).write(|w| unsafe { w.bits(value) });
+        phy.ac_base(1792 + reg_nr)
+            .write(|w| unsafe { w.bits(value) });
     });
     // 4 blocks of 256 each
     util_data1_a(0, 0x1);

--- a/src/mainboard/starfive/visionfive2/bt0/src/dram.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/dram.rs
@@ -110,24 +110,15 @@ pub fn init() {
 
         // inlined from ddr_setup()
         println!("[DRAM] train"); // dram_pi::init in VF1 code
-        train(init::DDR_PHY_CTRL_BASE);
+        train();
         println!("[DRAM] util"); // dram_phy::init in VF1 code
-        util(init::DDR_PHY_AC_BASE);
+        util();
         println!("[DRAM] start");
-        start(
-            init::DDR_PHY_BASE,
-            init::DDR_PHY_CTRL_BASE,
-            init::DDR_PHY_AC_BASE,
-        );
+        start();
         println!("[DRAM] set clk to OSC div2");
         init::clk_ddrc_osc_div2();
         println!("[DRAM] boot");
-        omc_init(
-            init::DDR_PHY_BASE,
-            init::DDR_CTRL_BASE,
-            init::DDR_SEC_CTRL_BASE,
-            init::DDR_PHY_CTRL_BASE,
-        );
+        omc_init();
         println!("[DRAM] init done");
     }
 }


### PR DESCRIPTION
Uses the `jh71xx-pac` library for DDR configuration in the VisionFive2 mainboard.