### PR TITLE
fixup: add riscv debuginfo and entrpoint for objdump

### DIFF
--- a/src/mainboard/starfive/visionfive1/bt0/.cargo/config.toml
+++ b/src/mainboard/starfive/visionfive1/bt0/.cargo/config.toml
@@ -5,4 +5,6 @@ target = "riscv64imac-unknown-none-elf"
 rustflags = [
   "-C",
   "link-arg=-Tlink-visionfive1-bt0.ld",
+  "-C",
+  "target-feature=+zicsr,+zifencei",
 ]

--- a/src/mainboard/starfive/visionfive1/bt0/src/main.rs
+++ b/src/mainboard/starfive/visionfive1/bt0/src/main.rs
@@ -64,7 +64,7 @@ static mut BT0_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 ///
 /// Naked function.
 #[naked]
-#[export_name = "start"]
+#[export_name = "_start"]
 #[link_section = ".text.entry"]
 #[allow(named_asm_labels)]
 pub unsafe extern "C" fn start() -> ! {

--- a/src/mainboard/starfive/visionfive1/main/.cargo/config.toml
+++ b/src/mainboard/starfive/visionfive1/main/.cargo/config.toml
@@ -5,4 +5,6 @@ target = "riscv64imac-unknown-none-elf"
 rustflags = [
   "-C",
   "link-arg=-Tlink-visionfive1-bt0.ld",
+  "-C",
+  "target-feature=+zicsr,+zifencei",
 ]

--- a/src/mainboard/starfive/visionfive1/main/src/main.rs
+++ b/src/mainboard/starfive/visionfive1/main/src/main.rs
@@ -21,7 +21,7 @@ static mut BT0_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 ///
 /// Naked function.
 #[naked]
-#[export_name = "start"]
+#[export_name = "_start"]
 #[link_section = ".text.entry"]
 pub unsafe extern "C" fn start() -> ! {
     asm!(

--- a/src/mainboard/starfive/visionfive2/bt0/.cargo/config.toml
+++ b/src/mainboard/starfive/visionfive2/bt0/.cargo/config.toml
@@ -5,4 +5,6 @@ target = "riscv64imac-unknown-none-elf"
 rustflags = [
   "-C",
   "link-arg=-Tlink-visionfive2-bt0.ld",
+  "-C",
+  "target-feature=+zicsr,+zifencei",
 ]

--- a/src/mainboard/starfive/visionfive2/bt0/src/main.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/main.rs
@@ -60,7 +60,7 @@ static mut BT0_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 ///
 /// Naked function.
 #[naked]
-#[export_name = "start"]
+#[export_name = "_start"]
 #[link_section = ".text.entry"]
 #[allow(named_asm_labels)]
 pub unsafe extern "C" fn start() -> ! {

--- a/src/mainboard/starfive/visionfive2/main/.cargo/config.toml
+++ b/src/mainboard/starfive/visionfive2/main/.cargo/config.toml
@@ -5,4 +5,6 @@ target = "riscv64imac-unknown-none-elf"
 rustflags = [
   "-C",
   "link-arg=-Tlink-visionfive2-main.ld",
+  "-C",
+  "target-feature=+zicsr,+zifencei",
 ]

--- a/src/mainboard/starfive/visionfive2/main/src/main.rs
+++ b/src/mainboard/starfive/visionfive2/main/src/main.rs
@@ -20,7 +20,7 @@ static mut BT0_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 ///
 /// Naked function.
 #[naked]
-#[export_name = "start"]
+#[export_name = "_start"]
 #[link_section = ".text.entry"]
 pub unsafe extern "C" fn start() -> ! {
     asm!(

--- a/src/mainboard/sunxi/nezha/bt0/.cargo/config.toml
+++ b/src/mainboard/sunxi/nezha/bt0/.cargo/config.toml
@@ -5,4 +5,6 @@ target = "riscv64imac-unknown-none-elf"
 rustflags = [
   "-C",
   "link-arg=-Tlink-nezha-bt0.ld",
+  "-C",
+  "target-feature=+zicsr,+zifencei",
 ]

--- a/src/mainboard/sunxi/nezha/bt0/build.rs
+++ b/src/mainboard/sunxi/nezha/bt0/build.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 const NEZHA_FLASH: &[u8] = b"
 OUTPUT_ARCH(riscv)
-ENTRY(head_jump)
+ENTRY(_head_jump)
 MEMORY {
     SRAM : ORIGIN = 0x00020000, LENGTH = 32K
 }

--- a/src/mainboard/sunxi/nezha/bt0/src/main.rs
+++ b/src/mainboard/sunxi/nezha/bt0/src/main.rs
@@ -49,14 +49,14 @@ static mut BT0_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 /// Naked function.
 #[naked]
 #[link_section = ".head.text"]
-#[export_name = "head_jump"]
+#[export_name = "_head_jump"]
 pub unsafe extern "C" fn head_jump() {
     asm!(
         ".option push",
         ".option rvc",
         "c.j    0x68", // 0x60: eGON.BT0 header; 0x08: FlashHead
         ".option pop",
-        // sym start,
+        // sym _start,
         options(noreturn)
     )
 }
@@ -253,7 +253,7 @@ This bit will be reset to 1’b0.
 /// See also what mainline U-Boot does
 /// <https://github.com/smaeul/u-boot/blob/55103cc657a4a84eabc9ae2dabfcab149b07934f/board/sunxi/board-riscv.c#L72-L75>
 #[naked]
-#[export_name = "start"]
+#[export_name = "_start"]
 #[link_section = ".text.entry"]
 pub unsafe extern "C" fn start() -> ! {
     asm!(

--- a/src/mainboard/sunxi/nezha/main/.cargo/config.toml
+++ b/src/mainboard/sunxi/nezha/main/.cargo/config.toml
@@ -7,4 +7,6 @@ rustflags = [
   "link-arg=-Tlink-nezha-main.ld",
   "-Z",
   "emit-stack-sizes",
+  "-C",
+  "target-feature=+zicsr,+zifencei",
 ]


### PR DESCRIPTION
add riscv debuginfo for easier debugging and rename elf entrypoint _start to match ENTRY in linker script