### PR TITLE
Bump rust version to 1.74

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 MAINBOARDS := $(wildcard src/mainboard/*/*/Makefile)
 
 # NOTE: These are the host utilities, requiring their own recent Rust version.
-RUST_VER := 1.73
+RUST_VER := 1.74
 BINUTILS_VER := 0.3.6
 TARPAULIN_VER := 0.27.1
 DPRINT_VER := 0.41.0


### PR DESCRIPTION
While trying to run `make firsttime`, it turns out clap_lex requires rust 1.74:

$ make firsttime
rustup run --install 1.73 cargo install --version 0.3.6 cargo-binutils
     Ignored package `cargo-binutils v0.3.6` is already installed, use --force to override
rustup run --install 1.73 cargo install --version 0.27.1 cargo-tarpaulin
    Updating crates.io index
  Installing cargo-tarpaulin v0.27.1
    Updating crates.io index
error: failed to compile `cargo-tarpaulin v0.27.1`, intermediate artifacts can be found at `/tmp/cargo-install7v3Pgi`. To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  package `clap_lex v0.7.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.73.0
  Try re-running cargo install with `--locked`
make: *** [Makefile:36: firsttime] Error 101