### PR TITLE
Add an explicit resolver to the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "xtask",
 ]
 default-members = ["xtask"]
+resolver = "2"
 
 [profile.release]
 opt-level = 'z' # Optimize for size.


### PR DESCRIPTION
This silences the warning:

warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`