### PR TITLE
Fix clippy warnings across the project

### DIFF
--- a/src/lib/compression/src/lib.rs
+++ b/src/lib/compression/src/lib.rs
@@ -13,7 +13,7 @@ const DECOMP_BUF_SIZE: usize = 1 << EI;
 const COMP_BUF_SIZE: usize = 2 << EI;
 pub type OreLzss = lzss::Lzss<EI, 4, 0x00, DECOMP_BUF_SIZE, COMP_BUF_SIZE>;
 
-/// Safety:
+/// # Safety
 ///
 /// The caller needs to ensure correctness of source and target addresses.
 /// The first four bytes at source address must hold the compressed size.

--- a/src/lib/layoutflash/src/areas.rs
+++ b/src/lib/layoutflash/src/areas.rs
@@ -10,7 +10,7 @@ pub struct FdtIterator<'a, 'b> {
 
 impl<'a, 'b> FdtIterator<'a, 'b> {
     pub fn new(iter: &'a mut dyn Iterator<Item = FdtNode<'b, 'b>>) -> FdtIterator<'a, 'b> {
-        FdtIterator { iter: iter }
+        FdtIterator { iter }
     }
 }
 
@@ -32,7 +32,7 @@ pub struct Area<'a> {
     pub file: Option<&'a str>,
 }
 
-pub fn find_fdt<'a>(data: &'a [u8]) -> Result<fdt::Fdt<'a>, fdt::FdtError> {
+pub fn find_fdt(data: &[u8]) -> Result<fdt::Fdt, fdt::FdtError> {
     // The informal standard is that the fdt must be on a 0x1000
     // boundary. It is a fine line between too coarse a boundary
     // and falling into an false positive.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -185,7 +185,7 @@ fn layout_flash(dir: &Path, path: &Path, areas: Vec<Area>) -> io::Result<()> {
             }
 
             // If the path is an unused environment variable, skip it.
-            if path.starts_with("$(") && path.ends_with(")") {
+            if path.starts_with("$(") && path.ends_with(')') {
                 continue;
             }
 

--- a/xtask/src/starfive/visionfive1.rs
+++ b/xtask/src/starfive/visionfive1.rs
@@ -55,14 +55,14 @@ pub(crate) fn execute_command(args: &crate::Cli, features: Vec<String>) {
     }
 }
 
-fn xtask_build_jh7100_flash_bt0(env: &Env, features: &Vec<String>) {
+fn xtask_build_jh7100_flash_bt0(env: &Env, features: &[String]) {
     trace!("build JH7100 flash bt0");
     let mut command = get_cargo_cmd_in(env, board_project_root(), "bt0", "build");
-    if features.len() != 0 {
+    if !features.is_empty() {
         let command_line_features = features.join(",");
         trace!("append command line features: {command_line_features}");
         command.arg("--no-default-features");
-        command.args(&["--features", &command_line_features]);
+        command.args(["--features", &command_line_features]);
     } else {
         trace!("no command line features appended");
     }

--- a/xtask/src/starfive/visionfive2.rs
+++ b/xtask/src/starfive/visionfive2.rs
@@ -53,7 +53,7 @@ pub(crate) fn execute_command(args: &Cli, features: Vec<String>) {
     }
 }
 
-fn xtask_build_jh7110_bt0(env: &Env, features: &Vec<String>) {
+fn xtask_build_jh7110_bt0(env: &Env, features: &[String]) {
     trace!("build JH7110 bt0");
     let mut command = get_cargo_cmd_in(env, board_project_root(), "bt0", "build");
     if !features.is_empty() {

--- a/xtask/src/sunxi/nezha.rs
+++ b/xtask/src/sunxi/nezha.rs
@@ -68,7 +68,7 @@ pub(crate) fn execute_command(args: &Cli, features: Vec<String>) {
     }
 }
 
-fn build_image(env: &Env, features: &Vec<String>) {
+fn build_image(env: &Env, features: &[String]) {
     // Get binutils first so we can fail early
     let binutils_prefix = &find_binutils_prefix_or_fail(ARCH);
     // Build the stages - should we parallelize this?
@@ -80,7 +80,7 @@ fn build_image(env: &Env, features: &Vec<String>) {
     concat_binaries(env);
 }
 
-fn build_d1_bt0(env: &Env, features: &Vec<String>) {
+fn build_d1_bt0(env: &Env, features: &[String]) {
     trace!("build D1 bt0");
     let mut command = get_cargo_cmd_in(env, board_project_root(), "bt0", "build");
     if !features.is_empty() {

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -24,7 +24,7 @@ pub fn get_cargo_cmd_in(env: &Env, root: PathBuf, dir: &str, command: &str) -> C
 }
 
 /// Compile the board device tree.
-pub fn compile_board_dt(env: &Env, target: &str, root: &PathBuf, dtb: &str) {
+pub fn compile_board_dt(env: &Env, target: &str, root: &Path, dtb: &str) {
     trace!("compile board device tree {dtb}");
     let cwd = dist_dir(env, target);
     let mut command = Command::new("dtc");


### PR DESCRIPTION
No functional changes, merely fixing `cargo clippy` warnings.