### PR TITLE
arch/riscv: ensure alignment via repr() directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 MAINBOARDS := $(wildcard src/mainboard/*/*/Makefile)
 
 # NOTE: These are the host utilities, requiring their own recent Rust version.
-RUST_VER := 1.74
+RUST_VER := 1.78
 BINUTILS_VER := 0.3.6
 TARPAULIN_VER := 0.27.1
 DPRINT_VER := 0.41.0

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(asm_const)]
+#![feature(fn_align)]
 #![feature(naked_functions)]
 #![feature(coroutine_trait)]
 #![no_std]

--- a/src/arch/src/riscv64/sbi/runtime.rs
+++ b/src/arch/src/riscv64/sbi/runtime.rs
@@ -42,11 +42,8 @@ fn delegate_interrupt_exception() {
 }
 
 pub fn init() {
-    let mut addr = from_supervisor_save as usize;
-    // Must be aligned to 4 bytes
-    if addr & 0x2 != 0 {
-        addr += 0x2;
-    }
+    // NOTE: This must be aligned to 4 bytes, asserted via repr() directive.
+    let addr = from_supervisor_save as usize;
     unsafe { mtvec::write(addr, TrapMode::Direct) };
     delegate_interrupt_exception();
 }
@@ -274,8 +271,10 @@ pub unsafe extern "C" fn to_supervisor_restore(_supervisor_context: *mut Supervi
 }
 
 // 中断开始
-
+/// # Safety
+/// NOTE: must be 4-byte aligned
 #[naked]
+#[repr(align(4))]
 #[link_section = ".text"]
 pub unsafe extern "C" fn from_supervisor_save() -> ! {
     asm!( // sp:特权级栈,mscratch:特权级上下文


### PR DESCRIPTION
The computation at runtime turned out to not work in practice.

Signed-off-by: Daniel Maslowski <info@orangecms.org>
