### PR TITLE
nezha: Fix first jump

### DIFF
--- a/src/mainboard/sunxi/nezha/bt0/build.rs
+++ b/src/mainboard/sunxi/nezha/bt0/build.rs
@@ -12,11 +12,9 @@ MEMORY {
 SECTIONS {
     .head : {
         *(.head.text)
-        KEEP(*(.head.egon))
-        KEEP(*(.head.main))
+        *(.head.egon)
     } > SRAM
     .text : {
-        KEEP(*(.text.entry))
         *(.text .text.*)
     } > SRAM
     .rodata : ALIGN(4) {


### PR DESCRIPTION
The KEEP linker directive does not prohibit the rust compiler to garbage collect code, unless #[used] is used. Therefore remove MainStageHead as it's effectively not there.

The first jump instruction did assume MainStageHead was there and therefore skipped the first 2 instructions of _start. This is now fixed.

This changes the first instruction to be in assembly rather than inline assembly as the rust compiler seems to like to pad the instruction with unimp.

This means that disabling interrupts and enabling "theadisaee" and "maee" is now correctly done.