### PR TITLE
refactor: return &'static Path when returning PathBuf is unnecessary

### DIFF
--- a/xtask/src/gdb_detect.rs
+++ b/xtask/src/gdb_detect.rs
@@ -1,7 +1,7 @@
 use log::{error, info};
 use std::fs;
 use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 pub fn detect_gdb_path() -> String {
@@ -126,10 +126,9 @@ pub fn load_gdb_server_from_file() -> io::Result<String> {
     )
 }
 
-fn project_root() -> PathBuf {
-    Path::new(&env!("CARGO_MANIFEST_DIR"))
+fn project_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(1)
         .unwrap()
-        .to_path_buf()
 }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -100,9 +100,11 @@ pub fn find_binutils_prefix_or_fail(arch: &str) -> String {
 }
 
 /// Get the oreboot root directory.
-pub fn project_root() -> PathBuf {
-    let d = &env!("CARGO_MANIFEST_DIR");
-    Path::new(d).ancestors().nth(1).unwrap().to_path_buf()
+pub fn project_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .unwrap()
 }
 
 /// Get the target specific build output directory.


### PR DESCRIPTION
- When returning a path, prefer using `&'static Path` instead of `PathBuf` when heap allocation is unnecessary.