### PR TITLE
Cargo.toml: use * to include all boards and lib crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,8 @@ members = [
   "src/console",
   "src/cpu",
   "src/soc",
-
-  "src/lib/compression",
-  "src/lib/consts",
-  "src/lib/log",
-  "src/lib/util",
-  "src/lib/layoutflash",
-
-  "src/mainboard/starfive/visionfive1/*",
-  "src/mainboard/starfive/visionfive2/*",
-  "src/mainboard/sunxi/nezha/*",
-  "src/mainboard/emulation/qemu-riscv/*",
-
+  "src/lib/*",
+  "src/mainboard/*/*/*",
   "xtask",
 ]
 default-members = ["xtask"]


### PR DESCRIPTION
This makes it simpler to new boards, stages, and libraries.