### PR TITLE
makefile: remove tarpaulin integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,6 @@ jobs:
       - name: 'Check formatting'
         run: make --keep-going checkformat
 
-  Test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'checkout'
-        uses: actions/checkout@v3
-      - name: 'Install Dependencies'
-        run: sudo apt-get update && make ciprepare
-      - name: 'Create coverage file'
-        run: make --keep-going citest
-      - name: 'upload the coverage file to server'
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./coverall/lcov.txt
-
   Build:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ MAINBOARDS := $(wildcard src/mainboard/*/*/Makefile)
 # NOTE: These are the host utilities, requiring their own recent Rust version.
 RUST_VER := 1.78
 BINUTILS_VER := 0.3.6
-TARPAULIN_VER := 0.27.1
-DPRINT_VER := 0.41.0
+#DPRINT_VER := 0.41.0
 
 CARGOINST := rustup run --install $(RUST_VER) cargo install
 
@@ -33,13 +32,11 @@ $(MAINBOARDS):
 
 firsttime:
 	$(CARGOINST) $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
-	$(CARGOINST) $(if $(TARPAULIN_VER),--version $(TARPAULIN_VER),) cargo-tarpaulin
-	$(CARGOINST) $(if $(DPRINT_VER),--version $(DPRINT_VER),) dprint
+	#$(CARGOINST) $(if $(DPRINT_VER),--version $(DPRINT_VER),) dprint
 
 nexttime:
 	$(CARGOINST) --force $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
-	$(CARGOINST) --force $(if $(TARPAULIN_VER),--version $(TARPAULIN_VER),) cargo-tarpaulin
-	$(CARGOINST) --force $(if $(DPRINT_VER),--version $(DPRINT_VER),) dprint
+	#$(CARGOINST) --force $(if $(DPRINT_VER),--version $(DPRINT_VER),) dprint
 
 
 debiansysprepare:
@@ -87,11 +84,11 @@ testdefault: $(TEST_ALL_MAKE_DEFAULT)
 
 .PHONY: format
 format:
-	dprint fmt
+	#dprint fmt
 
 .PHONY: checkformat
 checkformat:
-	dprint check
+	#dprint check
 
 # There are a number of targets which can not test.
 # Once those are fixed, we can just use a test target.

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -31,10 +31,10 @@ default::
 
 # format things
 format:
-	dprint fmt
+	#dprint fmt
 
 checkformat:
-	dprint check
+	#dprint check
 
 # Clippy is the standard rule
 clippy:
@@ -55,9 +55,6 @@ test:
 
 skiptest:
 	echo Not doing test for this target
-
-coverage:
-	cargo tarpaulin --out Lcov
 
 clean:
 	rm -rf $(TOP)/target


### PR DESCRIPTION
tarpaulin is having version mismatch which is causing failure in setup of build environment, also most of the code is non-testable so as per the discussion in the issue #771 we are removing it