### PR TITLE
makefile: upgrade rustc version to latest stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 MAINBOARDS := $(wildcard src/mainboard/*/*/Makefile)
 
 # NOTE: These are the host utilities, requiring their own recent Rust version.
-RUST_VER := 1.78
+RUST_VER := 1.85
 BINUTILS_VER := 0.3.6
 TARPAULIN_VER := 0.27.1
 DPRINT_VER := 0.41.0


### PR DESCRIPTION
upgrading the rustc version to latest stable 1.85.0 to solve dependency issues. 
solving #771 