### PR TITLE
makefile: remove tarpaulin integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,6 @@ jobs:
       - name: 'Check formatting'
         run: make --keep-going checkformat
 
-  Test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'checkout'
-        uses: actions/checkout@v3
-      - name: 'Install Dependencies'
-        run: sudo apt-get update && make ciprepare
-      - name: 'Create coverage file'
-        run: make --keep-going citest
-      - name: 'upload the coverage file to server'
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./coverall/lcov.txt
-
   Build:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ MAINBOARDS := $(wildcard src/mainboard/*/*/Makefile)
 # NOTE: These are the host utilities, requiring their own recent Rust version.
 RUST_VER := 1.85
 BINUTILS_VER := 0.3.6
-TARPAULIN_VER := 0.27.1
 DPRINT_VER := 0.41.0
 
 CARGOINST := rustup run --install $(RUST_VER) cargo install
@@ -33,12 +32,10 @@ $(MAINBOARDS):
 
 firsttime:
 	$(CARGOINST) $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
-	$(CARGOINST) $(if $(TARPAULIN_VER),--version $(TARPAULIN_VER),) cargo-tarpaulin
 	$(CARGOINST) $(if $(DPRINT_VER),--version $(DPRINT_VER),) dprint
 
 nexttime:
 	$(CARGOINST) --force $(if $(BINUTILS_VER),--version $(BINUTILS_VER),) cargo-binutils
-	$(CARGOINST) --force $(if $(TARPAULIN_VER),--version $(TARPAULIN_VER),) cargo-tarpaulin
 	$(CARGOINST) --force $(if $(DPRINT_VER),--version $(DPRINT_VER),) dprint
 
 
@@ -92,29 +89,6 @@ format:
 .PHONY: checkformat
 checkformat:
 	dprint check
-
-# There are a number of targets which can not test.
-# Once those are fixed, we can just use a test target.
-CRATES_TO_TEST := $(patsubst %/Makefile,%/Makefile.test,$(ALLMAKEFILE))
-$(CRATES_TO_TEST):
-	make --no-print-directory -C $(dir $@) test
-.PHONY: test $(CRATES_TO_TEST)
-
-# NOTE: In CI, we run tests with coverage report.
-# The individual crates' Makefiles use the `citest` target.
-# However, there are a number of crates which can not test.
-# Hence, `citest` either points to `coverage` or `skiptest`.
-# We use the LCOV format so that we can simply concatenate
-# the multiple reports. See ./Makefile.inc for details.
-CRATES_TO_CITEST := $(patsubst %/Makefile,%/Makefile.citest,$(ALLMAKEFILE))
-$(CRATES_TO_CITEST):
-	make --no-print-directory -C $(dir $@) citest
-.PHONY: test $(CRATES_TO_CITEST)
-citest: $(CRATES_TO_CITEST)
-	# concatenate all the results from the indidividual directories
-	mkdir -p coverall
-	find . -name "lcov.info" -exec cat > coverall/lcov.txt {} +
-
 
 # TODO: Remove write_with_newline
 CRATES_TO_CLIPPY := $(patsubst %/Makefile,%/Makefile.clippy,$(ALLMAKEFILE))

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -56,8 +56,5 @@ test:
 skiptest:
 	echo Not doing test for this target
 
-coverage:
-	cargo tarpaulin --out Lcov
-
 clean:
 	rm -rf $(TOP)/target

--- a/src/console/Makefile
+++ b/src/console/Makefile
@@ -1,4 +1,3 @@
 OREBOOT=$(abspath $(CURDIR)/../../)
 include ../../Makefile.inc
 ciclippy: clippy
-citest: coverage

--- a/src/lib/consts/Makefile
+++ b/src/lib/consts/Makefile
@@ -1,4 +1,3 @@
 OREBOOT=$(abspath $(CURDIR)/../../../)
 include ../../../Makefile.inc
 ciclippy: clippy
-citest: coverage

--- a/src/lib/util/Makefile
+++ b/src/lib/util/Makefile
@@ -1,4 +1,3 @@
 OREBOOT=$(abspath $(CURDIR)/../../../)
 include ../../../Makefile.inc
 ciclippy: clippy
-citest: coverage


### PR DESCRIPTION
most of the code is non-testable so as per the discussion in the issue #771 we are removing it.
also removed the `coverage` target from Makefiles