### PR TITLE
sunxi/nezha fixes + rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "rustsbi",
  "sbi-spec 0.0.4",
  "spin",
+ "util",
  "vcell",
 ]
 

--- a/src/arch/src/riscv64/mod.rs
+++ b/src/arch/src/riscv64/mod.rs
@@ -11,5 +11,5 @@ pub mod sbi {
     pub mod runtime;
 }
 
-mod util;
-mod xuantie;
+pub mod util;
+pub mod xuantie;

--- a/src/mainboard/sunxi/nezha/bt0/src/main.rs
+++ b/src/mainboard/sunxi/nezha/bt0/src/main.rs
@@ -59,7 +59,7 @@ pub struct EgonHead {
     magic: [u8; 8],
     checksum: u32,
     length: u32,
-    _padding: [u32; 3],
+    _padding: [u32; 19],
 }
 
 use core::mem::size_of;
@@ -85,7 +85,7 @@ pub static EGON_HEAD: EgonHead = EgonHead {
     magic: *b"eGON.BT0",
     checksum: STAMP_CHECKSUM,
     length: 0,
-    _padding: [0; 3],
+    _padding: [0; 19],
 };
 
 const STACK_SIZE: usize = 1 * 1024; // 1KiB

--- a/src/mainboard/sunxi/nezha/bt0/src/main.rs
+++ b/src/mainboard/sunxi/nezha/bt0/src/main.rs
@@ -88,7 +88,7 @@ pub static EGON_HEAD: EgonHead = EgonHead {
     _padding: [0; 19],
 };
 
-const STACK_SIZE: usize = 1 * 1024; // 1KiB
+const STACK_SIZE: usize = 2 * 1024;
 
 #[link_section = ".bss.uninit"]
 static mut BT0_STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];

--- a/src/mainboard/sunxi/nezha/bt0/src/main.rs
+++ b/src/mainboard/sunxi/nezha/bt0/src/main.rs
@@ -71,7 +71,7 @@ const STAMP_CHECKSUM: u32 = 0x5F0A6C39;
 // TODO: determine offets/sizes at build time
 // memory load addresses
 const LIN_ADDR: usize = RAM_BASE + 0x0400_0000; // Linux will be decompressed in payloader
-const DTB_ADDR: usize = RAM_BASE + 0x01a0_0000; // dtb must be 2MB aligned and behind Linux
+const DTB_ADDR: usize = RAM_BASE + 0x0220_0000; // dtb must be 2MB aligned and behind Linux
 const ORE_ADDR: usize = RAM_BASE;
 const ORE_SIZE: usize = 0x1_8000; // 96K
 const DTF_SIZE: usize = 0x1_0000; // 64K

--- a/src/mainboard/sunxi/nezha/main/Cargo.toml
+++ b/src/mainboard/sunxi/nezha/main/Cargo.toml
@@ -19,6 +19,7 @@ log = { path = "../../../../lib/log" }
 oreboot-arch = { path = "../../../../arch", features = ["riscv64"] }
 oreboot-soc = { path = "../../../../soc", features = ["sunxi_d1"] }
 oreboot_compression = { path = "../../../../lib/compression" }
+util = { path = "../../../../lib/util" }
 
 [features]
 default = []

--- a/src/mainboard/sunxi/nezha/main/src/main.rs
+++ b/src/mainboard/sunxi/nezha/main/src/main.rs
@@ -35,10 +35,10 @@ const LINUXBOOT_TMP_ADDR: usize = MEM + LINUXBOOT_TMP_OFFSET;
 // target location for decompressed image
 const LINUXBOOT_OFFSET: usize = 0x0020_0000;
 const LINUXBOOT_ADDR: usize = MEM + LINUXBOOT_OFFSET;
-const LINUXBOOT_SIZE: usize = 0x0180_0000;
+const LINUXBOOT_SIZE: usize = 0x0200_0000;
 // DTB_OFFSET should be >=LINUXBOOT_OFFSET+LINUXBOOT_SIZE and match bt0
 // TODO: Should we just copy it to a higher address before decompressing Linux?
-const DTB_OFFSET: usize = 0x01a0_0000;
+const DTB_OFFSET: usize = LINUXBOOT_OFFSET + LINUXBOOT_SIZE;
 const DTB_ADDR: usize = MEM + DTB_OFFSET;
 
 fn decompress_lb() {

--- a/src/soc/src/sunxi/d1/clint.rs
+++ b/src/soc/src/sunxi/d1/clint.rs
@@ -6,18 +6,7 @@ pub const UART_USR: usize = 0x7c;
 
 pub const CLINT_BASE: usize = 0x0400_0000;
 pub const MSIP0: usize = 0;
-pub const MTIMECMPL: usize = 0x4000;
 
-pub mod mtimecmp {
-    use super::{write_reg, CLINT_BASE, MTIMECMPL};
-    pub fn write(word: u64) {
-        unsafe {
-            let mask = u64::MAX;
-            write_reg(CLINT_BASE, MTIMECMPL, (word & mask) as u32);
-            write_reg(CLINT_BASE, MTIMECMPL + 4, (word >> 32) as u32);
-        }
-    }
-}
 pub mod msip {
     use super::{write_reg, CLINT_BASE, MSIP0};
 


### PR DESCRIPTION
This is in preparation of #772; the current only SoC we use our compression library for is the D1, so that's to be switched, and as it turns out, we had some breakage - and could already benefit  from our newly introduced XuanTie library.