### PR TITLE
pass optional CLINT base to SBI

### DIFF
--- a/src/arch/src/riscv64/sbi/feature/emulate_rdtime.rs
+++ b/src/arch/src/riscv64/sbi/feature/emulate_rdtime.rs
@@ -1,41 +1,61 @@
 use super::super::runtime::SupervisorContext;
-use core::arch::asm;
 use log::println;
 use riscv::register::cycle;
 
-const DEBUG_THIS: bool = false;
+const DEBUG: bool = false;
+const DEBUG_RDCYCLE: bool = false;
+const DEBUG_RDTIME: bool = false;
 
-// 0x4102573
+const RDINS_MASK: usize = 0xFFFF_F07F;
+const RDTIME_INST: usize = 0xC010_2073;
+const RDCYCLE_INST: usize = 0xC000_2073;
+
+pub fn get_mtime(mtime: Option<usize>) -> usize {
+    if let Some(r) = mtime {
+        util::mmio::read64le(r) as usize
+    } else {
+        riscv::register::time::read64() as usize
+    }
+}
 
 #[inline]
-pub fn emulate_rdtime(ctx: &mut SupervisorContext, ins: usize) -> bool {
-    //  c0002573     rdcycle a0
-    if ins & 0xFFFFF07F == 0xC0002073 {
-        let rd = ((ins >> 7) & 0b1_1111) as u8;
-        let cycle_usize = cycle::read64() as usize;
-        set_register_xi(ctx, rd, cycle_usize);
-        ctx.mepc = ctx.mepc.wrapping_add(4); // skip current instruction
-        println!("[rustsbi] rdcycle {:x}\r", cycle_usize);
-        true
-    }
-    // TODO: IS THIS CORRECT? Linux calls rdtime a *lot*.
-    else if ins & 0xFFFFF07F == 0xC0102073 {
-        // rdtime is actually a csrrw instruction
-        let rd = ((ins >> 7) & 0b1_1111) as u8;
-        let mtime: u64;
-        unsafe {
-            asm!("csrr {}, time", out(reg) mtime);
+pub fn emulate_rdtime(ctx: &mut SupervisorContext, ins: usize, mtime: Option<usize>) -> bool {
+    match ins & RDINS_MASK {
+        RDCYCLE_INST => {
+            // examples:
+            //  c0002573     rdcycle a0
+            let reg = ((ins >> 7) & 0b1_1111) as u8;
+            if DEBUG && DEBUG_RDCYCLE {
+                println!("[SBI] rdcycle {ins:08x} ({reg})");
+            }
+            let cycle_usize = cycle::read64() as usize;
+            set_register_xi(ctx, reg, cycle_usize);
+            if DEBUG && DEBUG_RDCYCLE {
+                println!("[SBI] rdcycle {cycle_usize:x}");
+            }
+            // skip current instruction, 4 bytes
+            ctx.mepc = ctx.mepc.wrapping_add(4);
+            true
         }
-        let time_usize = mtime as usize;
-        set_register_xi(ctx, rd, time_usize);
-        ctx.mepc = ctx.mepc.wrapping_add(4); // skip current instruction
-        let x = time_usize / 0x1000;
-        if DEBUG_THIS && x > 1 && x % 0x200 == 0 {
-            println!("[rustsbi] rdtime {:x}\r", time_usize);
+        RDTIME_INST => {
+            // examples:
+            //  c0102573     rdtime  a0    (reg = 10)
+            //  c01027f3     rdtime  a5    (reg = 15)
+            // rdtime is actually a csrrw instruction
+            let reg = ((ins >> 7) & 0b1_1111) as u8;
+            if DEBUG && DEBUG_RDTIME {
+                println!("[SBI] rdtime {ins:08x} ({reg})");
+            }
+            let mtime = get_mtime(mtime);
+            set_register_xi(ctx, reg, mtime);
+            if DEBUG && DEBUG_RDTIME {
+                println!("[SBI] rdtime {mtime:08x}: {mtime}");
+            }
+            // skip current instruction, 4 bytes
+            ctx.mepc = ctx.mepc.wrapping_add(4);
+            true
         }
-        true
-    } else {
-        false // is not a rdtime instruction
+        _ => false, // is not an rdXXX instruction
     }
 }
 

--- a/src/mainboard/canaan/canmv-k230/main/src/main.rs
+++ b/src/mainboard/canaan/canmv-k230/main/src/main.rs
@@ -267,7 +267,7 @@ fn exec_payload() {
         let hart_id = mhartid::read();
         let dtb_addr = 0;
         let (reset_type, reset_reason) =
-            ore_sbi::execute::execute_supervisor(sbi, payload_addr, hart_id, dtb_addr);
+            ore_sbi::execute::execute_supervisor(sbi, payload_addr, hart_id, dtb_addr, None);
         println!("[oreboot] reset reason: {reset_reason}");
     } else {
         unsafe {

--- a/src/mainboard/emulation/qemu-riscv/main/src/main.rs
+++ b/src/mainboard/emulation/qemu-riscv/main/src/main.rs
@@ -62,8 +62,13 @@ pub extern "C" fn _start(dtb_address: usize) -> ! {
     }
 
     let hart_id = mhartid::read();
-    let (reset_type, reset_reason) =
-        ore_sbi::execute::execute_supervisor(sbi, mem_map::PAYLOAD_ADDR, hart_id, dtb_address);
+    let (reset_type, reset_reason) = ore_sbi::execute::execute_supervisor(
+        sbi,
+        mem_map::PAYLOAD_ADDR,
+        hart_id,
+        dtb_address,
+        Some(mem_map::CLINT_BASE),
+    );
     println!("[oreboot] reset; reason: {reset_reason}, type: {reset_type}");
 
     loop {

--- a/src/mainboard/sunxi/nezha/main/src/main.rs
+++ b/src/mainboard/sunxi/nezha/main/src/main.rs
@@ -12,6 +12,7 @@ use log::{print, println};
 use oreboot_compression::decompress;
 use oreboot_soc::sunxi::d1::{
     ccu::Clocks,
+    clint::CLINT_BASE,
     gpio::Gpio,
     pac::{Peripherals, UART0},
     time::U32Ext,
@@ -325,9 +326,14 @@ extern "C" fn main() -> usize {
         println!("Enter supervisor at {PAYLOAD_ADDR:08x} with DTB from {DTB_ADDR:08x}");
 
         let hart_id = riscv::register::mhartid::read();
-        let (reset_type, reset_reason) =
-            ore_sbi::execute::execute_supervisor(sbi, PAYLOAD_ADDR, hart_id, DTB_ADDR);
-        println!("oreboot: reset reason = {reset_reason}");
+        let (reset_type, reset_reason) = ore_sbi::execute::execute_supervisor(
+            sbi,
+            PAYLOAD_ADDR,
+            hart_id,
+            DTB_ADDR,
+            Some(CLINT_BASE),
+        );
+        println!("[oreboot] reset reason: {reset_reason}");
         reset_type
     } else {
         // TODO: Do we need more stuff here?


### PR DESCRIPTION
This allows us to either use a RISC-V time register or the CLINT.