### PR TITLE
use mem::transmute instead of intrinsics::transmute

### DIFF
--- a/src/mainboard/canaan/canmv-k230/bt0/src/main.rs
+++ b/src/mainboard/canaan/canmv-k230/bt0/src/main.rs
@@ -8,7 +8,7 @@ extern crate log;
 
 use core::{
     arch::{asm, naked_asm},
-    intrinsics::transmute,
+    mem::transmute,
     panic::PanicInfo,
     ptr::{self, addr_of, addr_of_mut},
 };

--- a/src/mainboard/canaan/canmv-k230/main/src/main.rs
+++ b/src/mainboard/canaan/canmv-k230/main/src/main.rs
@@ -7,7 +7,7 @@
 extern crate log;
 use core::{
     arch::{asm, naked_asm},
-    intrinsics::transmute,
+    mem::transmute,
     panic::PanicInfo,
     ptr::{self, addr_of, addr_of_mut},
 };

--- a/src/mainboard/rockchip/rk3566/bt0/src/main.rs
+++ b/src/mainboard/rockchip/rk3566/bt0/src/main.rs
@@ -10,6 +10,7 @@ extern crate log;
 
 use core::{
     arch::{asm, naked_asm},
+    mem::transmute,
     panic::PanicInfo,
 };
 use log::println;
@@ -131,7 +132,7 @@ pub type EntryPoint = unsafe extern "C" fn();
 // jump to main stage or payload
 fn exec_payload(addr: usize) {
     unsafe {
-        let f: EntryPoint = core::intrinsics::transmute(addr);
+        let f: EntryPoint = transmute(addr);
         f();
     }
 }

--- a/src/mainboard/starfive/visionfive1/bt0/src/main.rs
+++ b/src/mainboard/starfive/visionfive1/bt0/src/main.rs
@@ -8,7 +8,7 @@ extern crate log;
 
 use core::{
     arch::{asm, naked_asm},
-    intrinsics::transmute,
+    mem::transmute,
     panic::PanicInfo,
     ptr::{self, read_volatile, write_volatile},
     slice,

--- a/src/mainboard/starfive/visionfive2/bt0/src/main.rs
+++ b/src/mainboard/starfive/visionfive2/bt0/src/main.rs
@@ -12,7 +12,7 @@ use layoutflash::areas::{find_fdt, FdtIterator};
 
 use core::{
     arch::{asm, naked_asm},
-    intrinsics::transmute,
+    mem::transmute,
     panic::PanicInfo,
     ptr::{self, addr_of, addr_of_mut},
 };

--- a/src/mainboard/sunxi/nezha/bt0/src/main.rs
+++ b/src/mainboard/sunxi/nezha/bt0/src/main.rs
@@ -3,7 +3,7 @@
 #![no_main]
 
 use core::arch::{asm, naked_asm};
-use core::intrinsics::transmute;
+use core::mem::transmute;
 use core::panic::PanicInfo;
 use core::ptr::{read_volatile, write_volatile};
 use embedded_hal::digital::OutputPin;


### PR DESCRIPTION
The former has been deprecated.

See https://doc.rust-lang.org/std/intrinsics/fn.transmute.html