### PR TITLE
starfive/visionfive2/bt0: configure cfg lints

### DIFF
--- a/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
+++ b/src/mainboard/starfive/visionfive2/bt0/Cargo.toml
@@ -22,3 +22,6 @@ soc = { path = "../../../../soc", package = "oreboot-soc", features = ["starfive
 [dependencies.jh71xx-hal]
 version = "0.1"
 features = ["rt"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dram_size, values("2G", "4G", "8G"))'] }


### PR DESCRIPTION
Cargo would now warn on features it doesn't know.
Instead of just declaring what features can take what values, they have to be listed in the `lints.rust` config section. See also: https://blog.rust-lang.org/2024/05/06/check-cfg/