### PR TITLE
xtask: fix clap annotations

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -102,12 +102,12 @@ struct Env {
     supervisor: bool,
     #[clap(long, global = true, help = "Mainboard to build")]
     mainboard: Option<String>,
+    #[clap(long, global = true, help = "Board variant")]
+    variant: Option<String>,
     #[clap(long, global = true, help = "Target memory description")]
     memory: Option<Memory>,
-    #[clap(long, global = true, help = "Board variant")]
-    dram_size: Option<DramSize>,
     #[clap(long, global = true, help = "DRAM size")]
-    variant: Option<String>,
+    dram_size: Option<DramSize>,
     #[clap(long, global = true, help = "Path to raw payload")]
     payload: Option<String>,
     #[clap(long, global = true, help = "Path to dtb")]


### PR DESCRIPTION
The help texts got in the wrong place, and noone noticed. Whoops!