### PR TITLE
Adding shell script for size check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ default-members = ["xtask"]
 resolver = "2"
 
 [profile.release]
+panic = "abort"
 opt-level = 'z' # Optimize for size.
 lto = true
 # Leave debug symbol information on release compilation mode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,13 @@ resolver = "2"
 
 [profile.release]
 panic = "abort"
+codegen-units = 1
+debug = 0
 opt-level = 'z' # Optimize for size.
 lto = true
 # Leave debug symbol information on release compilation mode
 # That's okay, these symbols won't appear on flash binary
-debug = true
+# debug = true
 
 [profile.dev]
 opt-level = 1 # Use slightly better optimizations.

--- a/check_size.sh
+++ b/check_size.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -e
+
+# Detect platform
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+IS_WINDOWS=false
+if [[ "$OS" == *"mingw"* ]] || [[ "$OS" == *"cygwin"* ]] || [[ "$OS" == *"msys"* ]]; then
+    IS_WINDOWS=true
+fi
+
+# Binary paths
+if $IS_WINDOWS; then
+    BINARY_ELF="target/release/xtask.exe"
+    STRIP_CMD="llvm-strip"  # Use llvm-strip or mingw strip
+else
+    BINARY_ELF="target/release/xtask"
+    STRIP_CMD="strip"
+fi
+BINARY_BIN="${BINARY_ELF%.*}.bin"
+
+# Build
+echo " Building in release mode..."
+cargo build --release
+
+# Check binary exists
+if [ ! -f "$BINARY_ELF" ]; then
+    echo " Could not find the release binary. Build may have failed."
+    exit 1
+fi
+
+# Size before strip
+echo " Binary size before strip:"
+ls -lh "$BINARY_ELF"
+if command -v size &> /dev/null; then
+    echo "Section sizes:"
+    size "$BINARY_ELF" || true
+fi
+
+# Strip symbols
+if command -v $STRIP_CMD &> /dev/null; then
+    echo "Stripping symbols with $STRIP_CMD..."
+    $STRIP_CMD "$BINARY_ELF" || echo "⚠ Strip failed"
+else
+    echo "Strip command ($STRIP_CMD) not found. Skipping..."
+fi
+
+# Size after strip
+echo " Binary size after strip:"
+ls -lh "$BINARY_ELF"
+if command -v size &> /dev/null; then
+    echo "Section sizes:"
+    size "$BINARY_ELF" || true
+fi
+
+# Generate raw .bin
+if command -v objcopy &> /dev/null; then
+    echo " Generating raw .bin file..."
+    objcopy -O binary "$BINARY_ELF" "$BINARY_BIN" || echo " objcopy failed"
+    ls -lh "$BINARY_BIN"
+else
+    echo " objcopy not found. Skipping .bin generation."
+fi
+
+# Cargo bloat
+if command -v cargo-bloat &> /dev/null; then
+    echo " Running cargo-bloat (top 20 functions):"
+    cargo bloat --release -n 20
+else
+    echo " cargo-bloat not installed. Skipping."
+fi

--- a/check_size.sh
+++ b/check_size.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# Detect platform
+# Detect OS
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 IS_WINDOWS=false
 if [[ "$OS" == *"mingw"* ]] || [[ "$OS" == *"cygwin"* ]] || [[ "$OS" == *"msys"* ]]; then
@@ -10,58 +10,76 @@ fi
 
 # Binary paths
 if $IS_WINDOWS; then
-    BINARY_ELF="target/release/xtask.exe"
-    STRIP_CMD="llvm-strip"  # Use llvm-strip or mingw strip
+    BINARY="target/release/xtask.exe"
+    STRIP_CMD="llvm-strip"  # or mingw-strip
 else
-    BINARY_ELF="target/release/xtask"
+    BINARY="target/release/xtask"
     STRIP_CMD="strip"
 fi
-BINARY_BIN="${BINARY_ELF%.*}.bin"
+BINARY_BIN="${BINARY%.*}.bin"
 
-# Build
+# Ensure Cargo.toml has [profile.release] section with size optimizations
+PROFILE_SETTINGS=$(cat <<EOL
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
+debug = 0
+strip = true
+EOL
+)
+
+# Append only if [profile.release] not already exists
+if ! grep -q "^\[profile.release\]" Cargo.toml; then
+    echo "$PROFILE_SETTINGS" >> Cargo.toml
+    echo " Applied min-sized-rust optimizations to Cargo.toml"
+else
+    echo " [profile.release] exists in Cargo.toml. Make sure it has opt-level=z, lto=true, panic=abort, etc."
+fi
+
 echo " Building in release mode..."
 cargo build --release
 
 # Check binary exists
-if [ ! -f "$BINARY_ELF" ]; then
+if [ ! -f "$BINARY" ]; then
     echo " Could not find the release binary. Build may have failed."
     exit 1
 fi
 
-# Size before strip
+# Show size before strip
 echo " Binary size before strip:"
-ls -lh "$BINARY_ELF"
+ls -lh "$BINARY"
 if command -v size &> /dev/null; then
-    echo "Section sizes:"
-    size "$BINARY_ELF" || true
+    size "$BINARY" || true
 fi
 
-# Strip symbols
+# Strip binary
 if command -v $STRIP_CMD &> /dev/null; then
-    echo "Stripping symbols with $STRIP_CMD..."
-    $STRIP_CMD "$BINARY_ELF" || echo "⚠ Strip failed"
+    echo " Stripping symbols with $STRIP_CMD..."
+    $STRIP_CMD "$BINARY" || echo "⚠ Strip failed"
 else
-    echo "Strip command ($STRIP_CMD) not found. Skipping..."
+    echo "⚠ Strip command ($STRIP_CMD) not found. Skipping..."
 fi
 
-# Size after strip
-echo " Binary size after strip:"
-ls -lh "$BINARY_ELF"
+# Show size after strip
+echo "Binary size after strip:"
+ls -lh "$BINARY"
 if command -v size &> /dev/null; then
-    echo "Section sizes:"
-    size "$BINARY_ELF" || true
+    size "$BINARY" || true
 fi
 
 # Generate raw .bin
 if command -v objcopy &> /dev/null; then
     echo " Generating raw .bin file..."
-    objcopy -O binary "$BINARY_ELF" "$BINARY_BIN" || echo " objcopy failed"
+    objcopy -O binary "$BINARY" "$BINARY_BIN" || echo "⚠ objcopy failed"
     ls -lh "$BINARY_BIN"
 else
-    echo " objcopy not found. Skipping .bin generation."
+    echo "⚠ objcopy not found. Skipping .bin generation."
 fi
 
-# Cargo bloat
+# Run cargo-bloat
 if command -v cargo-bloat &> /dev/null; then
     echo " Running cargo-bloat (top 20 functions):"
     cargo bloat --release -n 20


### PR DESCRIPTION
Adding a shell script for size checking, for windows and linux , for now the optimization is just with the strip flag ,will add more flags to optimize the size more.
Solves issue : https://github.com/oreboot/oreboot/issues/797
<img width="830" height="665" alt="image" src="https://github.com/user-attachments/assets/485543dd-4ff3-435c-b93b-52fb9b1d10a5" />

more changes through cargo.toml tested through:
<img width="518" height="49" alt="image" src="https://github.com/user-attachments/assets/3b47a3db-b70f-4ae8-8e1b-e1bd679ecdea" />

With adding the panic : size reduces significantly 
<img width="520" height="106" alt="image" src="https://github.com/user-attachments/assets/26baf979-2aca-4d74-8a36-7dbaeae3e8a4" />
```
[profile.release]
panic = "abort"
```
It avoids including Rust’s unwinding machinery, which can be a few hundred KB in .exe files.
Especially effective for small binaries or embedded targets.

<img width="513" height="106" alt="image" src="https://github.com/user-attachments/assets/9b767ee2-032f-471a-8289-46f25972ddf1" />

```
[profile.release]
codegen-units = 1
```
* This didnt create much variation in size though.
Fewer codegen units → smaller and better-optimized binaries.
Tradeoff: longer compile time, but smaller size.

`[profile.release]
debug = 0`

* Strips debug info during compilation — reduces .exe size.
<img width="627" height="56" alt="image" src="https://github.com/user-attachments/assets/fb6983c2-9a8b-4352-babd-1fd5db57809d" />

-> But not much changes were seen in the output size.