### PR TITLE
fix make run on starfive mainboards

### DIFF
--- a/src/mainboard/starfive/visionfive1/Makefile
+++ b/src/mainboard/starfive/visionfive1/Makefile
@@ -3,7 +3,7 @@ TARGET     = riscv64imac-unknown-none-elf
 # full image path, including multiple stages
 IMAGE_BASE = $(OREBOOT)/target/$(TARGET)/release/starfive-visionfive1
 IMAGE_BT0 := $(IMAGE_BASE)-bt0
-IMAGE   := $(IMAGE_BASE).bin
+IMAGE   := $(OREBOOT)/src/mainboard/starfive/visionfive1/starfive-visionfive1.bin
 VERBOSE ?= -vvvv
 PORT    := /dev/ttyUSB0
 

--- a/src/mainboard/starfive/visionfive2/Makefile
+++ b/src/mainboard/starfive/visionfive2/Makefile
@@ -8,7 +8,7 @@ VF2LOADER ?= vf2-loader
 # full image path, including multiple stages
 IMAGE_BASE  = $(OREBOOT)/target/$(TARGET)/release/starfive-visionfive2
 IMAGE_BT0  := $(IMAGE_BASE)-bt0
-IMAGE      := $(IMAGE_BASE).bin
+IMAGE      := $(OREBOOT)/src/mainboard/starfive/visionfive2/starfive-visionfive2.bin
 
 cibuild: mainboard
 


### PR DESCRIPTION
These artifacts that are to be flashed are not actually put into $(OREBOOT)/target/... but in their respective mainboard directory.