### PR TITLE
scripts: fix size report

### DIFF
--- a/scripts/generate-size-report.sh
+++ b/scripts/generate-size-report.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 echo "Mainboard;Size(bytes)"
-for BOOTBLOB in $(find ./target -name *-bootblob.bin)
+for BIN in $(find ./target/*/release/ -name *.bin)
 do
-  SIZE=$(stat -c"%s" $BOOTBLOB)
-  if [[ $BOOTBLOB =~ \./target/.*/([^/]+)-([^/]+)-bootblob.bin ]]; then 
+  SIZE=$(stat -c"%s" $BIN)
+  if [[ $BIN =~ \./target/.*/([^/]+)-([^/]+).bin ]]; then 
     echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]};${SIZE}"
   fi 
 done


### PR DESCRIPTION
We never really used this script in a long while, which broke without anyone noticing. It was meant to list binary sizes of 'bootblobs', what we now call the bt0 stage. Also include the main stage now.