### PR TITLE
Upgrade Rust to nightly-2026-05-06

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@
 members = [
   "src/arch",
   "src/cpu",
-  "src/soc",
   "src/lib/*",
   "src/mainboard/*/*/*",
+  "src/soc",
   "xtask",
 ]
 default-members = ["xtask"]

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ help:
 	@echo 'format -- to format all files'
 
 # NOTE: These are the host utilities, requiring their own recent Rust version.
-RUST_VER := 1.90
+RUST_VER := 1.95
 BINUTILS_VER := 0.4.0
-DPRINT_VER := 0.50.2
+DPRINT_VER := 0.54.0
 
 # cargo command wrapper and shorthands
 CARGO := rustup run --install $(RUST_VER) cargo

--- a/dprint.json
+++ b/dprint.json
@@ -18,9 +18,9 @@
     "3rdparty/"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/exec-0.4.4.json@c207bf9b9a4ee1f0ecb75c594f774924baf62e8e53a2ce9d873816a408cecbf7",
-    "https://plugins.dprint.dev/json-0.19.1.wasm",
-    "https://plugins.dprint.dev/markdown-0.16.3.wasm",
-    "https://plugins.dprint.dev/toml-0.5.4.wasm"
+    "https://plugins.dprint.dev/exec-0.6.2.json@df98f54ffd3092b8a841aedd6d098a2651f16d0a796a40535774f1a8b4b9d463",
+    "https://plugins.dprint.dev/json-0.21.3.wasm",
+    "https://plugins.dprint.dev/markdown-0.21.1.wasm",
+    "https://plugins.dprint.dev/toml-0.7.0.wasm"
   ]
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-09-06"
+channel = "nightly-2026-05-06"
 components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]
 targets = [
   "riscv32imac-unknown-none-elf",


### PR DESCRIPTION
a half of the year has passed again - time for the upgrades

this also bumps the Rust version for the tooling, the tooling itself, and the dprint plugins