### PR TITLE
xtask: log info level by default

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,7 +1,7 @@
 use std::{env, process, str::FromStr};
 
 use clap::{Args, Parser, Subcommand};
-use clap_verbosity_flag::Verbosity;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
 use log::{error, info};
 
 mod gdb_detect;
@@ -21,7 +21,7 @@ struct Cli {
     #[clap(flatten)]
     env: Env,
     #[clap(flatten)]
-    verbose: Verbosity,
+    verbose: Verbosity<InfoLevel>,
 }
 
 #[derive(Subcommand, Debug)]


### PR DESCRIPTION
I thought we used to have this. There is no 'log' log level, and 'info' is our default instead for uniform output; using regular print!/println! macros would only be confusing.