### PR TITLE
xtask: more notes on commands

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,7 +14,7 @@ mod sunxi;
 
 #[derive(Parser)]
 #[clap(name = "xtask")]
-#[clap(about = "Program that help you build and debug Oreboot project", long_about = None)]
+#[clap(about = "The oreboot build system", long_about = None)]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,
@@ -26,13 +26,13 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Make this project
+    /// Make this project, i.e., build a full image
     Make,
-    /// Build flash and burn into target
+    /// Build image and flash to target
     Flash,
-    /// View assembly code
+    /// View assembly code, as in objdump
     Asm,
-    /// Debug code using gdb
+    /// Debug code using gdb, as supported by the platform
     Gdb,
 }
 


### PR DESCRIPTION
A trivial one, just being more informative to the user of the build system/tool.

```
The oreboot build system

Usage: xtask [OPTIONS] <COMMAND>

Commands:
  make   Make this project, i.e., build a full image
  flash  Build image and flash to target
  asm    View assembly code, as in objdump
  gdb    Debug code using gdb, as supported by the platform
  help   Print this message or the help of the given subcommand(s)

Options:
      --release                Build in release mode
      --supervisor             Build with arch-specific supervisor support
      --mainboard <MAINBOARD>  Mainboard to build
      --variant <VARIANT>      Board variant
      --memory <MEMORY>        Target memory description
      --dram-size <DRAM_SIZE>  DRAM size
      --payload <PAYLOAD>      Path to raw payload
      --dtb <DTB>              Path to dtb
  -v, --verbose...             Increase logging verbosity
  -q, --quiet...               Decrease logging verbosity
  -h, --help                   Print help
```