### PR TITLE
add analyze command

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,5 +5,6 @@ asm = "xtask asm"
 flash = "xtask flash"
 # debug = "xtask debug"
 gdb = "xtask gdb"
+analyze = "xtask analyze"
 
 # todo: xtask qemu for emulation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,12 +67,13 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -750,6 +751,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,12 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "sbi-rt"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,15 +1226,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1494,11 +1495,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1506,6 +1507,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1523,6 +1530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1615,6 +1631,8 @@ dependencies = [
  "log 0.4.22",
  "miniz_oxide",
  "pathdiff",
+ "serde",
+ "serde_json",
  "zerocopy",
  "zerocopy-derive",
 ]
@@ -1659,3 +1677,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/src/mainboard/sunxi/nezha/bt0/.cargo/config.toml
+++ b/src/mainboard/sunxi/nezha/bt0/.cargo/config.toml
@@ -7,4 +7,6 @@ rustflags = [
   "link-arg=-Tlink-nezha-bt0.ld",
   "-C",
   "target-feature=+zicsr,+zifencei",
+  "-Z",
+  "emit-stack-sizes",
 ]

--- a/src/mainboard/sunxi/nezha/bt0/build.rs
+++ b/src/mainboard/sunxi/nezha/bt0/build.rs
@@ -40,6 +40,9 @@ SECTIONS {
         *(.sbss .sbss.*)
         ebss = .;
     } > SRAM
+    .stack_sizes (INFO) : {
+        KEEP(*(.stack_sizes));
+    }
     /DISCARD/ : {
         *(.eh_frame)
     }

--- a/src/mainboard/sunxi/nezha/main/.cargo/config.toml
+++ b/src/mainboard/sunxi/nezha/main/.cargo/config.toml
@@ -5,8 +5,8 @@ target = "riscv64imac-unknown-none-elf"
 rustflags = [
   "-C",
   "link-arg=-Tlink-nezha-main.ld",
-  "-Z",
-  "emit-stack-sizes",
   "-C",
   "target-feature=+zicsr,+zifencei",
+  "-Z",
+  "emit-stack-sizes",
 ]

--- a/src/mainboard/sunxi/nezha/main/build.rs
+++ b/src/mainboard/sunxi/nezha/main/build.rs
@@ -36,6 +36,9 @@ SECTIONS {
         *(.sbss .sbss.*)
         ebss = .;
     } > DDR
+    .stack_sizes (INFO) : {
+        KEEP(*(.stack_sizes));
+    }
     /DISCARD/ : {
         *(.eh_frame)
     }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,11 +17,13 @@ config = "0.15.18"
 fdt = "0.1.4"
 miniz_oxide = "0.8.5"
 pathdiff = "0.2"
-zerocopy = "0.8.27"
-zerocopy-derive = "0.8.27"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
 
 # bit/byte manipulation, crypto and hashing
 byteorder = "1"
 crc = "*"
+zerocopy = "0.8.27"
+zerocopy-derive = "0.8.27"
 
 layoutflash = { path = "../src/lib/layoutflash", features = ["std"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -32,6 +32,8 @@ enum Commands {
     Flash,
     /// Run without flashing, as supported by the platform
     Run,
+    /// Analyze stack sizes and other properties
+    Analyze,
     /// View assembly code, as in objdump
     Asm,
     /// Debug code using gdb, as supported by the platform

--- a/xtask/src/qemu/riscv.rs
+++ b/xtask/src/qemu/riscv.rs
@@ -11,8 +11,8 @@ use log::{error, info, trace};
 use layoutflash::layout::{create_areas, layout_flash};
 
 use crate::util::{
-    compile_platform_dt, find_binutils_prefix_or_fail, get_bin_for, get_cargo_cmd_in, objcopy,
-    platform_dir, target_bin, Bin,
+    analyze, compile_platform_dt, find_binutils_prefix_or_fail, get_bin_for, get_cargo_cmd_in,
+    objcopy, platform_dir, target_bin, Bin,
 };
 use crate::{Cli, Commands, Env};
 
@@ -34,6 +34,11 @@ pub(crate) fn execute_command(args: &Cli, dir: &PathBuf, features: Vec<String>) 
         Commands::Make => {
             info!("Build oreboot image for QEMU RISC-V");
             build(&args.env, dir, &stages, &features);
+        }
+        Commands::Analyze => {
+            info!("Build and analyze main stage");
+            build_main(&args.env, dir, &stages.main);
+            analyze(&args.env, &stages.main);
         }
         _ => {
             error!("command {:?} not implemented", args.command);

--- a/xtask/src/sunxi/nezha.rs
+++ b/xtask/src/sunxi/nezha.rs
@@ -8,8 +8,8 @@ use std::{
 use log::{error, info, trace};
 
 use crate::util::{
-    find_binutils_prefix_or_fail, get_bin_for, get_cargo_cmd_in, objcopy, objdump, platform_dir,
-    target_dir, Bin,
+    analyze, find_binutils_prefix_or_fail, get_bin_for, get_cargo_cmd_in, objcopy, objdump,
+    platform_dir, target_dir, Bin,
 };
 use crate::{
     gdb_detect,
@@ -72,6 +72,13 @@ pub(crate) fn execute_command(args: &Cli, dir: &PathBuf, features: Vec<String>) 
                 ans
             };
             debug_gdb(&args.env, &stages.bt0, &gdb_path, &gdb_server);
+        }
+        Commands::Analyze => {
+            info!("Build bt0 and analyze for D1");
+            build_bt0(&args.env, dir, &stages.bt0, &features);
+            analyze(&args.env, &stages.bt0);
+            build_main(&args.env, dir, &stages.bt0);
+            analyze(&args.env, &stages.main);
         }
         _ => {
             todo!("implement {:?} command", args.command);

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -1,9 +1,12 @@
-use crate::Env;
-use log::{error, trace};
 use std::{
     path::{Path, PathBuf},
     process::{self, Command, Stdio},
 };
+
+use log::{debug, error, info, trace};
+use serde::{Deserialize, Serialize};
+
+use crate::Env;
 
 // These utilities help find and run external commands.
 // Those are mostly toolchain components and vendor specific tools.
@@ -114,6 +117,86 @@ pub fn objdump(env: &Env, bin: &Bin, prefix: &str) {
     cmd.arg(&bin.elf_name);
     cmd.arg("-d");
     cmd.status().unwrap();
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct FileSummary {
+    file: String,
+    format: String,
+    arch: String,
+    address_size: String,
+    load_name: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct StackSizeEntry {
+    functions: Vec<String>,
+    size: usize,
+}
+
+impl core::fmt::Display for StackSizeEntry {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        let functions = self.functions.join(", ");
+        write!(f, "{:5} bytes; {functions}", self.size)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct StackSize {
+    entry: StackSizeEntry,
+}
+
+impl core::fmt::Display for StackSize {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        write!(f, "{}", self.entry)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct StackAnalysis {
+    file_summary: FileSummary,
+    stack_sizes: Vec<StackSize>,
+}
+
+/// Analyze an ELF for its stack size using readobj.
+///
+/// NOTE: If this fails, something is wrong with the command invocation.
+/// In that case, check the debug output.
+/// TODO: There may be crates for doing this, or programmatic interfaces.
+pub fn analyze(env: &Env, bin: &Bin) {
+    let mut cmd = Command::new("rust-readobj");
+    let dir = target_dir(env, &bin.target);
+    cmd.current_dir(dir);
+    cmd.arg(&bin.elf_name);
+    cmd.arg("--demangle");
+    cmd.arg("--stack-sizes");
+    cmd.arg("--elf-output-style");
+    cmd.arg("JSON");
+    debug!("{cmd:?}");
+    let output = cmd.output().unwrap();
+    let outstr = str::from_utf8(&output.stdout).unwrap();
+    debug!("{outstr}");
+
+    let mut parsed: Vec<StackAnalysis> = serde_json::from_str(outstr).unwrap();
+    let summary = &parsed[0].file_summary;
+    info!("{summary:#?}");
+
+    let entries = &mut parsed[0].stack_sizes;
+    entries.sort_by_key(|e| e.entry.size);
+    let biggest = entries
+        .iter()
+        .rev()
+        .take(10)
+        .map(|e| e.entry.clone())
+        .collect::<Vec<StackSizeEntry>>();
+    info!("Largest stack size entries:");
+    for e in biggest {
+        info!("  {e}");
+    }
 }
 
 /// Figure out the prefix for a toolchain's binutils.


### PR DESCRIPTION
for a start, we get stack sizes; example output:

```
[2026-05-21T22:46:41Z INFO  xtask::util] FileSummary {
        file: "emulation-qemu-riscv-main",
        format: "elf64-littleriscv",
        arch: "riscv64",
        address_size: "64bit",
        load_name: "<Not found>",
    }
[2026-05-21T22:46:41Z INFO  xtask::util] Largest entries:
[2026-05-21T22:46:41Z INFO  xtask::util]     608 bytes; <oreboot_arch::riscv64::sbi::runtime::SupervisorContext as core::fmt::Debug>::fmt
[2026-05-21T22:46:41Z INFO  xtask::util]     592 bytes; _start
[2026-05-21T22:46:41Z INFO  xtask::util]     144 bytes; <core::fmt::builders::DebugStruct>::field
[2026-05-21T22:46:41Z INFO  xtask::util]     144 bytes; <core::fmt::builders::PadAdapter as core::fmt::Write>::write_str
[2026-05-21T22:46:41Z INFO  xtask::util]     128 bytes; <core::fmt::Formatter>::debug_tuple_field1_finish
[2026-05-21T22:46:41Z INFO  xtask::util]     128 bytes; <core::fmt::Formatter>::pad_integral
[2026-05-21T22:46:41Z INFO  xtask::util]     128 bytes; core::fmt::write
[2026-05-21T22:46:41Z INFO  xtask::util]      96 bytes; oreboot_arch::riscv64::sbi::execute::dump_mstate
[2026-05-21T22:46:41Z INFO  xtask::util]      96 bytes; <core::fmt::Formatter>::pad
[2026-05-21T22:46:41Z INFO  xtask::util]      80 bytes; oreboot_arch::riscv64::sbi::feature::transfer_trap::do_transfer_trap::<riscv::interrupt::machine::Interrupt, riscv::interrupt::machine::Exception>
```