### PR TITLE
emulation/qemu-riscv: add target features zicsr+zifencei

### DIFF
--- a/src/mainboard/emulation/qemu-riscv/main/.cargo/config.toml
+++ b/src/mainboard/emulation/qemu-riscv/main/.cargo/config.toml
@@ -5,6 +5,8 @@ target = "riscv64imac-unknown-none-elf"
 rustflags = [
   "-C",
   "link-arg=-Tlink.ld",
+  "-C",
+  "target-feature=+zicsr,+zifencei",
   "-Z",
   "emit-stack-sizes",
 ]


### PR DESCRIPTION
This aligns with the other configs.

Cargo now also supports includes, so we may make use of that. Other multi-target projects do that already.