### PR TITLE
emulation/qemu-riscv: fix PMP config for the payload

### DIFF
--- a/src/mainboard/emulation/qemu-riscv/main/src/sbi_platform.rs
+++ b/src/mainboard/emulation/qemu-riscv/main/src/sbi_platform.rs
@@ -16,12 +16,35 @@ pub fn init() -> PlatSbi {
 }
 
 fn init_pmp() {
-    let cfg = 0x0f090fusize; // pmpaddr1 is read-only
+    // pmpcfg0 packs eight 8-bit entries (RV64: entries 0..=7). Each byte:
+    //
+    //   bit    7   6   5   4   3   2   1   0
+    //        +---+---+---+---+---+---+---+---+
+    //        | L | - | - | A | A | X | W | R |
+    //        +---+---+---+---+---+---+---+---+
+    //          |             |     |   |   |
+    //          |             |     |   |   +--> R : read
+    //          |             |     |   +------> W : write
+    //          |             |     +----------> X : execute
+    //          |             +----------------> A : 0=OFF, 1=TOR, 2=NA4, 3=NAPOT
+    //          +------------------------------> L : lock
+    //
+    //   0x0f = R|W|X | TOR      0x09 = R | TOR      0x1f = R|W|X | NAPOT
+    //
+    //   entry 0: TOR   [0x0, 0x8000_0000)            RWX  MMIO / low memory
+    //   entry 1: TOR   [0x8000_0000, 0x8020_0000)    R    oreboot/SBI firmware
+    //   entry 2: NAPOT [0x0, 0xffff_ffff_ffff_ffff]  RWX  payload RAM
+    //
+    // Note: `entry 2` uses NAPOT with pmpaddr = all-ones, the spec's encoding for the
+    // entire address space. Being the highest-numbered entry it is lowest priority,
+    // so entries 0 and 1 still protect their ranges;
+    // NAPOT (unlike TOR) can also cover the uppermost word.
+    let cfg = 0x1f090fusize;
     reg::pmpcfg0::write(cfg);
     reg::pmpcfg2::write(0); // nothing active here
     reg::pmpaddr0::write(0x80000000usize >> 2);
     reg::pmpaddr1::write(0x80200000usize >> 2);
-    reg::pmpaddr2::write(0xffffffffusize >> 2);
+    reg::pmpaddr2::write(usize::MAX);
 }
 
 use core::ptr::{read_volatile, write_volatile};

--- a/src/mainboard/emulation/qemu-riscv/main/src/sbi_platform.rs
+++ b/src/mainboard/emulation/qemu-riscv/main/src/sbi_platform.rs
@@ -16,11 +16,12 @@ pub fn init() -> PlatSbi {
 }
 
 fn init_pmp() {
-    let cfg = 0x0f0f0f0f0fusize; // pmpaddr0-1 and pmpaddr2-3 are read-only
+    let cfg = 0x0f090fusize; // pmpaddr1 is read-only
     reg::pmpcfg0::write(cfg);
     reg::pmpcfg2::write(0); // nothing active here
     reg::pmpaddr0::write(0x80000000usize >> 2);
     reg::pmpaddr1::write(0x80200000usize >> 2);
+    reg::pmpaddr2::write(0xffffffffusize >> 2);
 }
 
 use core::ptr::{read_volatile, write_volatile};


### PR DESCRIPTION
Hello Team,

When i tried to run the qemu-riscv example using sbitest payload, i didn't get any output from the payload, though oreboot ran fine:
```sh
❯ make PAYLOAD="/path/to/sbitest_qemu.bin" run
oreboot 🦀 main
RustSBI version 0.4.0
.______       __    __      _______.___________.  _______..______   __
|   _  \     |  |  |  |    /       |           | /       ||   _  \ |  |
|  |_)  |    |  |  |  |   |   (----`---|  |----`|   (----`|  |_)  ||  |
|      /     |  |  |  |    \   \       |  |      \   \    |   _  < |  |
|  |\  \----.|  `--'  |.----)   |      |  |  .----)   |   |  |_)  ||  |
| _| `._____| \______/ |_______/       |__|  |_______/    |______/ |__|
Platform Name: QEMU RISC-V
Implementation: oreboot version 0.1.0
[rustsbi] misa: RV64ACDFHIMSU
[rustsbi] mideleg: ssoft stimer sext (0x001666)
[rustsbi] medeleg: ima ia lma la sma sa uecall ipage lpage spage (0x00b1f3)
[rustsbi] mie: msoft ssoft mtimer stimer mext sext (0x000aaa)
[rustsbi] PMP0: 0x00000000 - 0x80000000 (A,R,W,X)
[rustsbi] PMP1: 0x80000000 - 0x80200000 (A,R,W,X)
[rustsbi] PMP2: 0x80200000 - 0x00000000 (A,R,W,X)
[rustsbi] PMP3: 0x00000000 - 0x00000000 (A,R,W,X)
[rustsbi] PMP4: 0x00000000 - 0x00000000 (A,R,W,X)
[rustsbi] PMP8: 0x00000000 - 0x00000000 (A,R,W,X)
[SBI] Prepare supervisor on hart 0 at 80200000 with DTB from bfe00000
[SBI] Enter loop...
```

When i enabled the interrupts/exceptions debug log from qemu, i found out that PAYLOAD is faulting continuously in loop with **"Instruction access fault"**:
```sh
cd oreboot/src/mainboard/emulation/qemu-riscv/main 
make mainboard
IMG=oreboot/target/riscv64imac-unknown-none-elf/release/emulation-qemu-riscv.bin 
PL=sbitest_qemu.bin
LOG=qemu.log
timeout -s KILL 5 qemu-system-riscv64 -m 1g -machine virt -nographic -bios $IMG -device loader,addr=0x80200000,file=$PL -d int -D $LOG
```
> excerpt from qemu.log file:
```sh
riscv_cpu_do_interrupt: hart:0, async:1, cause:0000000000000007, epc:0x0000000080200000, tval:0x0000000000000000, desc=m_timer
riscv_cpu_do_interrupt: hart:0, async:0, cause:0000000000000001, epc:0x0000000080200000, tval:0x0000000080200000, desc=fault_fetch
riscv_cpu_do_interrupt: hart:0, async:0, cause:0000000000000001, epc:0x0000000000000000, tval:0x0000000000000000, desc=fault_fetch
riscv_cpu_do_interrupt: hart:0, async:0, cause:0000000000000001, epc:0x0000000000000000, tval:0x0000000000000000, desc=fault_fetch
riscv_cpu_do_interrupt: hart:0, async:0, cause:0000000000000001, epc:0x0000000000000000, tval:0x0000000000000000, desc=fault_fetch
riscv_cpu_do_interrupt: hart:0, async:0, cause:0000000000000001, epc:0x0000000000000000, tval:0x0000000000000000, desc=fault_fetch
...
```

This issue arises because of **wrong PMP configuration for PAYLOAD**:
- we are missing `RWX access to PAYLOAD RAM.`
- oreboot firmware region [0x80000000, 0x80200000) is `changed from RWX to read-only for S-mode`, so that payload can't corrupt the SBI, matching the protective pattern used by the nezha/k230 boards.

This PR fixes above issues and now qemu runs successfully:
```sh
❯ make PAYLOAD="/path/to/sbitest_qemu.bin" run
oreboot 🦀 main
RustSBI version 0.4.0
.______       __    __      _______.___________.  _______..______   __
|   _  \     |  |  |  |    /       |           | /       ||   _  \ |  |
|  |_)  |    |  |  |  |   |   (----`---|  |----`|   (----`|  |_)  ||  |
|      /     |  |  |  |    \   \       |  |      \   \    |   _  < |  |
|  |\  \----.|  `--'  |.----)   |      |  |  .----)   |   |  |_)  ||  |
| _| `._____| \______/ |_______/       |__|  |_______/    |______/ |__|
Platform Name: QEMU RISC-V
Implementation: oreboot version 0.1.0
[rustsbi] misa: RV64ACDFHIMSU
[rustsbi] mideleg: ssoft stimer sext (0x001666)
[rustsbi] medeleg: ima ia lma la sma sa uecall ipage lpage spage (0x00b1f3)
[rustsbi] mie: msoft ssoft mtimer stimer mext sext (0x000aaa)
[rustsbi] PMP0: 0x00000000 - 0x80000000 (A,R,W,X)
[rustsbi] PMP1: 0x80000000 - 0x80200000 (A,R)
[rustsbi] PMP2: 0x80200000 - 0xfffffffc (A,R,W,X)
[rustsbi] PMP8: 0x00000000 - 0x00000000 (A,R,W,X)
[SBI] Prepare supervisor on hart 0 at 80200000 with DTB from bfe00000
[SBI] Enter loop...
A TEST
LOOP
LOOP
LOOP
LOOP
LOOP
LOOP
LOOP
LOOP
LOOP
LOOP
LOOP
LOOP
LOOP
LOOP
INTERRUPT
LOOP
LOOP
QEMU: Terminated
```